### PR TITLE
Fix PostHog SDK state processing compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,16 @@ jobs:
             cargo install worker-build@^0.7
           fi
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
 
       - name: Install JS test dependencies
-        run: bun install --cwd tests/js_client
+        run: bun install --cwd tests/js_client --frozen-lockfile
 
       - name: Verify Docker Compose
         run: docker compose version

--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ class_name = "GroupDurableObject"
 
 [[migrations]]
 tag = "v1"
-new_classes = ["PersonDurableObject"]
+new_sqlite_classes = ["PersonDurableObject"]
 
 [[migrations]]
 tag = "v2"
-new_classes = ["PersonIdCounterDurableObject", "GroupDurableObject"]
+new_sqlite_classes = ["PersonIdCounterDurableObject", "GroupDurableObject"]
 ```
 
 ### Secrets

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,8 +3,8 @@ use std::{net::SocketAddr, time::Duration};
 #[cfg(not(target_arch = "wasm32"))]
 use std::env::{self, VarError};
 
-use url::Url;
 use thiserror::Error;
+use url::Url;
 
 use crate::feature_flags::FeatureFlagStore;
 
@@ -42,9 +42,7 @@ pub enum ConfigError {
 impl Config {
     #[cfg(target_arch = "wasm32")]
     pub fn from_worker_env(env: &worker::Env) -> Result<Self, ConfigError> {
-        let address: SocketAddr = "0.0.0.0:8080"
-            .parse::<SocketAddr>()
-            .map_err(|err| {
+        let address: SocketAddr = "0.0.0.0:8080".parse::<SocketAddr>().map_err(|err| {
             ConfigError::InvalidSocketAddress {
                 value: "0.0.0.0:8080".to_string(),
                 message: err.to_string(),
@@ -93,15 +91,12 @@ impl Config {
         ];
 
         let posthog_team_id = match env.var("POSTHOG_TEAM_ID") {
-            Ok(value) => Some(
-                value
-                    .to_string()
-                    .parse::<i64>()
-                    .map_err(|err| ConfigError::InvalidTeamId {
-                        value: value.to_string(),
-                        message: err.to_string(),
-                    })?,
-            ),
+            Ok(value) => Some(value.to_string().parse::<i64>().map_err(|err| {
+                ConfigError::InvalidTeamId {
+                    value: value.to_string(),
+                    message: err.to_string(),
+                }
+            })?),
             Err(_) => None,
         };
 
@@ -114,7 +109,11 @@ impl Config {
             .secret("POSTHOG_SIGNING_SECRET")
             .ok()
             .map(|secret| secret.to_string())
-            .or_else(|| env.var("POSTHOG_SIGNING_SECRET").ok().map(|v| v.to_string()));
+            .or_else(|| {
+                env.var("POSTHOG_SIGNING_SECRET")
+                    .ok()
+                    .map(|v| v.to_string())
+            });
         let person_debug_token = env.var("PERSON_DEBUG_TOKEN").ok().map(|v| v.to_string());
         let feature_flags_raw = env
             .secret("HOGFLARE_FEATURE_FLAGS")

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::{collections::HashMap, io::Read};
 
 use axum::async_trait;
 use axum::body::{to_bytes, Body};
@@ -58,16 +58,13 @@ where
 {
     type Rejection = Infallible;
 
-    async fn from_request_parts(
-        parts: &mut Parts,
-        _state: &S,
-    ) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let properties = build_enrichment_properties(parts);
         Ok(Self { properties })
     }
 }
 
-trait ApplyApiKey {
+pub(crate) trait ApplyApiKey {
     fn ensure_api_key(&mut self, api_key: &str);
 }
 
@@ -238,13 +235,18 @@ where
     ) -> Result<Self, Self::Rejection> {
         let (parts, body) = request.into_parts();
         let headers = parts.headers;
+        let query = parts.uri.query().map(str::to_string);
         let bytes = to_bytes(body, usize::MAX)
             .await
             .map_err(PayloadExtractorError::BodyRead)?;
 
         verify_signature(&headers, &bytes, state.signing_secret.as_deref())?;
         let decoded = decode_content_encoding(&headers, &bytes)?;
-        let mut payloads = parse_posthog_body::<T>(&headers, &decoded)?;
+        let query_params = parse_query_params(query.as_deref())?;
+        let query_compression = query_param(&query_params, "compression")
+            .or_else(|| query_param(&query_params, "compression_method"));
+        let mut payloads =
+            parse_posthog_body_with_compression::<T>(&headers, &decoded, query_compression)?;
         let header_api_key = header_api_key(&headers);
         apply_api_key(&mut payloads, header_api_key.as_deref());
         let sent_at = header_sent_at(&headers);
@@ -266,13 +268,17 @@ impl FromRequest<AppState, Body> for PostHogBatchPayload {
     ) -> Result<Self, Self::Rejection> {
         let (parts, body) = request.into_parts();
         let headers = parts.headers;
+        let query = parts.uri.query().map(str::to_string);
         let bytes = to_bytes(body, usize::MAX)
             .await
             .map_err(PayloadExtractorError::BodyRead)?;
 
         verify_signature(&headers, &bytes, state.signing_secret.as_deref())?;
         let decoded = decode_content_encoding(&headers, &bytes)?;
-        let mut payload = parse_posthog_batch_body(&headers, &decoded)?;
+        let query_params = parse_query_params(query.as_deref())?;
+        let query_compression = query_param(&query_params, "compression")
+            .or_else(|| query_param(&query_params, "compression_method"));
+        let mut payload = parse_posthog_batch_body(&headers, &decoded, query_compression)?;
         let header_api_key = header_api_key(&headers);
         if payload.api_key.is_none() {
             payload.api_key = header_api_key;
@@ -398,7 +404,29 @@ fn constant_time_eq_hex(expected: &[u8], provided: &str) -> bool {
     expected_hex.as_bytes().ct_eq(cleaned.as_bytes()).into()
 }
 
-fn parse_posthog_body<T>(headers: &HeaderMap, body: &[u8]) -> Result<Vec<T>, PayloadExtractorError>
+fn parse_query_params(
+    query: Option<&str>,
+) -> Result<HashMap<String, String>, PayloadExtractorError> {
+    let Some(query) = query else {
+        return Ok(HashMap::new());
+    };
+    let pairs: Vec<(String, String)> =
+        serde_urlencoded::from_str(query).map_err(PayloadExtractorError::Form)?;
+    Ok(pairs.into_iter().collect())
+}
+
+fn query_param<'a>(params: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    params
+        .get(key)
+        .map(String::as_str)
+        .filter(|value| !value.is_empty() && *value != "undefined")
+}
+
+fn parse_posthog_body_with_compression<T>(
+    headers: &HeaderMap,
+    body: &[u8],
+    query_compression: Option<&str>,
+) -> Result<Vec<T>, PayloadExtractorError>
 where
     T: DeserializeOwned,
 {
@@ -419,8 +447,15 @@ where
         Some("application/x-www-form-urlencoded")
     );
 
+    if let Some(compression) = query_compression {
+        if !is_form && !body.starts_with(b"data=") {
+            let decoded = decode_compressed_body(body, compression)?;
+            return parse_json_payload(&decoded);
+        }
+    }
+
     if is_form || body.starts_with(b"data=") {
-        parse_form_payload(body)
+        parse_form_payload(body, query_compression)
     } else {
         parse_json_payload(body)
     }
@@ -429,6 +464,7 @@ where
 fn parse_posthog_batch_body(
     headers: &HeaderMap,
     body: &[u8],
+    query_compression: Option<&str>,
 ) -> Result<BatchRequest, PayloadExtractorError> {
     let content_type = headers
         .get(header::CONTENT_TYPE)
@@ -447,14 +483,24 @@ fn parse_posthog_batch_body(
         Some("application/x-www-form-urlencoded")
     );
 
+    if let Some(compression) = query_compression {
+        if !is_form && !body.starts_with(b"data=") {
+            let decoded = decode_compressed_body(body, compression)?;
+            return parse_json_batch_payload(&decoded);
+        }
+    }
+
     if is_form || body.starts_with(b"data=") {
-        parse_form_batch_payload(body)
+        parse_form_batch_payload(body, query_compression)
     } else {
         parse_json_batch_payload(body)
     }
 }
 
-fn parse_form_payload<T>(body: &[u8]) -> Result<Vec<T>, PayloadExtractorError>
+fn parse_form_payload<T>(
+    body: &[u8],
+    query_compression: Option<&str>,
+) -> Result<Vec<T>, PayloadExtractorError>
 where
     T: DeserializeOwned,
 {
@@ -476,11 +522,14 @@ where
     }
 
     let data = data_value.ok_or(PayloadExtractorError::MissingData)?;
-    let payloads = decode_data_value(data, compression.as_deref())?;
+    let payloads = decode_data_value(data, compression.as_deref().or(query_compression))?;
     deserialize_events(payloads, shared)
 }
 
-fn parse_form_batch_payload(body: &[u8]) -> Result<BatchRequest, PayloadExtractorError> {
+fn parse_form_batch_payload(
+    body: &[u8],
+    query_compression: Option<&str>,
+) -> Result<BatchRequest, PayloadExtractorError> {
     let form_pairs: Vec<(String, String)> =
         serde_urlencoded::from_bytes(body).map_err(PayloadExtractorError::Form)?;
 
@@ -499,7 +548,7 @@ fn parse_form_batch_payload(body: &[u8]) -> Result<BatchRequest, PayloadExtracto
     }
 
     let data = data_value.ok_or(PayloadExtractorError::MissingData)?;
-    let content = decode_data_content(data, compression.as_deref())?;
+    let content = decode_data_content(data, compression.as_deref().or(query_compression))?;
     apply_batch_data(content, &mut map)?;
 
     serde_json::from_value(Value::Object(map)).map_err(PayloadExtractorError::Json)
@@ -599,17 +648,19 @@ fn decode_data_string(
         .unwrap_or_else(|_| data.as_bytes().to_vec());
 
     let decoded = match compression.map(|value| value.to_ascii_lowercase()) {
+        Some(ref algo) if algo == "base64" => raw.clone(),
         Some(ref algo) if algo == "gzip" => decompress_gzip(&raw)?,
-        Some(ref algo) if algo == "gzip-js" || algo == "zlib" || algo == "deflate" => {
-            decompress_zlib(&raw)?
+        Some(ref algo) if algo == "gzip-js" => {
+            decompress_gzip(&raw).or_else(|_| decompress_zlib(&raw))?
         }
+        Some(ref algo) if algo == "zlib" || algo == "deflate" => decompress_zlib(&raw)?,
         Some(algo) => return Err(PayloadExtractorError::UnsupportedCompression(algo)),
         None => raw.clone(),
     };
 
     match serde_json::from_slice::<Value>(&decoded) {
         Ok(value) => convert_embedded_value(value),
-        Err(mut err) => {
+        Err(err) => {
             if compression.is_none() {
                 if let Ok(zlib_decoded) = decompress_zlib(&raw) {
                     if let Ok(value) = serde_json::from_slice::<Value>(&zlib_decoded) {
@@ -624,9 +675,28 @@ fn decode_data_string(
                 }
             }
 
-            err = serde_json::from_slice::<Value>(&decoded).unwrap_err();
             Err(PayloadExtractorError::Json(err))
         }
+    }
+}
+
+fn decode_compressed_body(
+    body: &[u8],
+    compression: &str,
+) -> Result<Vec<u8>, PayloadExtractorError> {
+    match compression.to_ascii_lowercase().as_str() {
+        "base64" => BASE64_STANDARD.decode(body).map_err(|err| {
+            PayloadExtractorError::Json(serde_json::Error::io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                err,
+            )))
+        }),
+        "gzip" => decompress_gzip(body),
+        "gzip-js" => decompress_gzip(body).or_else(|_| decompress_zlib(body)),
+        "zlib" | "deflate" => decompress_zlib(body),
+        other => Err(PayloadExtractorError::UnsupportedCompression(
+            other.to_string(),
+        )),
     }
 }
 
@@ -773,10 +843,7 @@ mod tests {
     use std::{io::Write, sync::Arc, time::Duration};
 
     use crate::{
-        models::CaptureRequest,
-        pipeline::PipelineClient,
-        persons::NoopPersonStore,
-        AppState,
+        models::CaptureRequest, persons::NoopPersonStore, pipeline::PipelineClient, AppState,
     };
     use reqwest::Url;
 
@@ -913,7 +980,7 @@ mod tests {
         })
         .to_string();
 
-        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         encoder.write_all(event.as_bytes()).unwrap();
         let compressed = encoder.finish().unwrap();
         let encoded = BASE64_STANDARD.encode(compressed);
@@ -936,6 +1003,65 @@ mod tests {
         assert_eq!(payload.items[0].event, "compressed-form");
         assert_eq!(payload.items[0].distinct_id, "form-user");
         assert_eq!(payload.items[0].api_key.as_deref(), Some("phc_compressed"));
+    }
+
+    #[tokio::test]
+    async fn parses_raw_gzip_js_payload_from_query() {
+        let body = json!({
+            "event": "raw-gzip-js",
+            "distinct_id": "raw-user",
+            "api_key": "phc_raw_gzip_js"
+        })
+        .to_string();
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(body.as_bytes()).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let request = Request::builder()
+            .uri("/capture?compression=gzip-js")
+            .header(header::CONTENT_TYPE, "text/plain")
+            .body(Body::from(compressed))
+            .unwrap();
+
+        let state = test_state();
+        let payload: PostHogPayload<CaptureRequest> =
+            PostHogPayload::from_request(request, &state).await.unwrap();
+
+        assert_eq!(payload.items.len(), 1);
+        assert_eq!(payload.items[0].event, "raw-gzip-js");
+        assert_eq!(payload.items[0].distinct_id, "raw-user");
+        assert_eq!(payload.items[0].api_key.as_deref(), Some("phc_raw_gzip_js"));
+    }
+
+    #[tokio::test]
+    async fn parses_base64_form_payload_from_query_compression() {
+        let event = json!({
+            "event": "query-base64",
+            "distinct_id": "base64-user",
+        })
+        .to_string();
+
+        let encoded = BASE64_STANDARD.encode(event);
+        let body = format!("data={}&api_key=phc_query_base64", encoded);
+
+        let request = Request::builder()
+            .uri("/capture?compression=base64")
+            .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .body(Body::from(body))
+            .unwrap();
+
+        let state = test_state();
+        let payload: PostHogPayload<CaptureRequest> =
+            PostHogPayload::from_request(request, &state).await.unwrap();
+
+        assert_eq!(payload.items.len(), 1);
+        assert_eq!(payload.items[0].event, "query-base64");
+        assert_eq!(payload.items[0].distinct_id, "base64-user");
+        assert_eq!(
+            payload.items[0].api_key.as_deref(),
+            Some("phc_query_base64")
+        );
     }
 
     #[tokio::test]

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -28,12 +28,16 @@ impl FeatureFlagStore {
     pub fn from_json(raw: &str) -> Result<Self, serde_json::Error> {
         let trimmed = raw.trim();
         if trimmed.starts_with('[') {
-            let flags: Vec<FeatureFlagDefinition> = serde_json::from_str(trimmed)?;
+            let mut flags: Vec<FeatureFlagDefinition> = serde_json::from_str(trimmed)?;
+            normalize_flags(&mut flags, &HashMap::new());
             return Ok(Self { flags });
         }
 
-        let parsed: FeatureFlagConfig = serde_json::from_str(trimmed)?;
-        Ok(Self { flags: parsed.flags })
+        let mut parsed: FeatureFlagConfig = serde_json::from_str(trimmed)?;
+        normalize_flags(&mut parsed.flags, &parsed.group_type_mapping);
+        Ok(Self {
+            flags: parsed.flags,
+        })
     }
 
     pub fn evaluate(&self, ctx: &FeatureFlagContext) -> FeatureFlagEvaluation {
@@ -71,6 +75,8 @@ impl FeatureFlagStore {
 struct FeatureFlagConfig {
     #[serde(default)]
     flags: Vec<FeatureFlagDefinition>,
+    #[serde(default)]
+    group_type_mapping: HashMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -102,6 +108,8 @@ pub struct FeatureFlagDefinition {
     pub evaluation_environments: Option<Vec<String>>,
     #[serde(default)]
     pub salt: Option<String>,
+    #[serde(default)]
+    filters: Option<PostHogFlagFilters>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
@@ -133,9 +141,28 @@ pub struct FeatureFlagCondition {
     pub variant: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize, Default)]
+struct PostHogFlagFilters {
+    #[serde(default)]
+    groups: Vec<FeatureFlagCondition>,
+    #[serde(default)]
+    multivariate: Option<PostHogMultivariate>,
+    #[serde(default)]
+    payloads: HashMap<String, Value>,
+    #[serde(default)]
+    aggregation_group_type_index: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct PostHogMultivariate {
+    #[serde(default)]
+    variants: Vec<FeatureFlagVariant>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct PropertyFilter {
     pub key: String,
+    #[serde(default)]
     pub value: Value,
     #[serde(default, rename = "type")]
     pub property_type: Option<String>,
@@ -143,6 +170,91 @@ pub struct PropertyFilter {
     pub group_type: Option<String>,
     #[serde(default, alias = "op", rename = "operator")]
     pub operator: Option<String>,
+}
+
+fn normalize_flags(
+    flags: &mut [FeatureFlagDefinition],
+    group_type_mapping: &HashMap<String, Value>,
+) {
+    for flag in flags {
+        if let Some(filters) = flag.filters.clone() {
+            if flag.conditions.is_empty() && !filters.groups.is_empty() {
+                flag.conditions = filters.groups;
+            }
+
+            if flag.variants.is_empty() {
+                if let Some(multivariate) = filters.multivariate {
+                    flag.variants = multivariate.variants;
+                }
+            }
+
+            if flag.flag_type == FeatureFlagType::Boolean && !flag.variants.is_empty() {
+                flag.flag_type = FeatureFlagType::Multivariate;
+            }
+
+            if flag.payload.is_none() {
+                flag.payload = filters
+                    .payloads
+                    .get("true")
+                    .or_else(|| filters.payloads.get("True"))
+                    .cloned();
+            }
+
+            if flag.variant_payloads.is_empty() {
+                for (key, value) in &filters.payloads {
+                    if key != "true" && key != "false" && key != "True" && key != "False" {
+                        flag.variant_payloads.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+
+            if flag.group_type.is_none() {
+                if let Some(index) = filters.aggregation_group_type_index {
+                    flag.group_type = group_type_from_mapping(group_type_mapping, index);
+                }
+            }
+        }
+
+        normalize_embedded_payloads(flag);
+    }
+}
+
+fn normalize_embedded_payloads(flag: &mut FeatureFlagDefinition) {
+    if let Some(payload) = flag.payload.take() {
+        flag.payload = Some(normalize_payload_value(payload));
+    }
+
+    for value in flag.variant_payloads.values_mut() {
+        *value = normalize_payload_value(value.take());
+    }
+
+    for variant in &mut flag.variants {
+        if let Some(payload) = variant.payload.take() {
+            variant.payload = Some(normalize_payload_value(payload));
+        }
+    }
+}
+
+fn normalize_payload_value(value: Value) -> Value {
+    match value {
+        Value::String(text) => serde_json::from_str::<Value>(&text).unwrap_or(Value::String(text)),
+        other => other,
+    }
+}
+
+fn group_type_from_mapping(mapping: &HashMap<String, Value>, index: i64) -> Option<String> {
+    let index_key = index.to_string();
+    if let Some(value) = mapping.get(&index_key).and_then(Value::as_str) {
+        return Some(value.to_string());
+    }
+
+    mapping.iter().find_map(|(key, value)| {
+        if value.as_i64() == Some(index) || value.as_str() == Some(index_key.as_str()) {
+            Some(key.clone())
+        } else {
+            None
+        }
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -238,7 +350,7 @@ fn evaluate_flag(flag: &FeatureFlagDefinition, ctx: &FeatureFlagContext) -> Flag
 
     if !flag.conditions.is_empty() {
         for (index, condition) in flag.conditions.iter().enumerate() {
-            if !properties_match(&condition.properties, ctx) {
+            if !properties_match(&condition.properties, ctx, flag.group_type.as_deref()) {
                 continue;
             }
             return evaluate_condition(flag, condition, ctx, &payloads, Some(index));
@@ -294,8 +406,8 @@ fn evaluate_condition(
         .or(flag.rollout_percentage)
         .unwrap_or(100.0);
 
-    let salt = flag.salt.as_deref().unwrap_or(&flag.key);
-    let bucket = bucket_for(salt, &hash_id);
+    let salt = flag.salt.as_deref().unwrap_or("");
+    let bucket = bucket_for(&flag.key, &hash_id, salt);
     let allowed = bucket < rollout.max(0.0).min(100.0);
 
     if !allowed {
@@ -328,7 +440,7 @@ fn evaluate_condition(
             );
         }
 
-        if let Some(selected) = pick_variant(variants, salt, &hash_id) {
+        if let Some(selected) = pick_variant(variants, &flag.key, &hash_id) {
             let payload = variant_payloads.get(&selected).cloned();
             return build_evaluation(
                 flag,
@@ -358,9 +470,13 @@ fn resolve_hash_id(flag: &FeatureFlagDefinition, ctx: &FeatureFlagContext) -> Op
     Some(ctx.distinct_id.clone())
 }
 
-fn properties_match(filters: &[PropertyFilter], ctx: &FeatureFlagContext) -> bool {
+fn properties_match(
+    filters: &[PropertyFilter],
+    ctx: &FeatureFlagContext,
+    flag_group_type: Option<&str>,
+) -> bool {
     for filter in filters {
-        if !property_matches(filter, ctx) {
+        if !property_matches(filter, ctx, flag_group_type) {
             return false;
         }
     }
@@ -368,16 +484,12 @@ fn properties_match(filters: &[PropertyFilter], ctx: &FeatureFlagContext) -> boo
     true
 }
 
-fn pick_variant(
-    variants: &[FeatureFlagVariant],
-    salt: &str,
-    hash_id: &str,
-) -> Option<String> {
+fn pick_variant(variants: &[FeatureFlagVariant], key: &str, hash_id: &str) -> Option<String> {
     if variants.is_empty() {
         return None;
     }
 
-    let bucket = bucket_for(salt, hash_id);
+    let bucket = bucket_for(key, hash_id, "variant");
     let mut cumulative = 0.0;
     for variant in variants {
         cumulative += variant.rollout_percentage.max(0.0);
@@ -389,16 +501,18 @@ fn pick_variant(
     None
 }
 
-fn bucket_for(salt: &str, hash_id: &str) -> f64 {
+fn bucket_for(key: &str, hash_id: &str, salt: &str) -> f64 {
+    const LONG_SCALE: u64 = 0x0fffffffffffffff;
     let mut hasher = Sha1::new();
-    hasher.update(salt.as_bytes());
-    hasher.update(b":");
+    hasher.update(key.as_bytes());
+    hasher.update(b".");
     hasher.update(hash_id.as_bytes());
+    hasher.update(salt.as_bytes());
     let digest = hasher.finalize();
     let mut bytes = [0u8; 8];
     bytes.copy_from_slice(&digest[..8]);
-    let value = u64::from_be_bytes(bytes);
-    (value % 100) as f64
+    let value = u64::from_be_bytes(bytes) >> 4;
+    (value as f64 / LONG_SCALE as f64) * 100.0
 }
 
 fn default_true() -> bool {
@@ -428,7 +542,10 @@ fn flag_detail(result: &FlagEvaluation) -> Value {
         metadata.insert("version".to_string(), Value::Number(version.into()));
     }
     if let Some(description) = &result.flag_description {
-        metadata.insert("description".to_string(), Value::String(description.clone()));
+        metadata.insert(
+            "description".to_string(),
+            Value::String(description.clone()),
+        );
     }
     if let Some(payload) = &result.payload {
         let payload_str = serde_json::to_string(payload).unwrap_or_else(|_| "null".to_string());
@@ -478,24 +595,35 @@ fn flag_matches_environment(flag: &FeatureFlagDefinition, envs: &HashSet<String>
     }
 }
 
-fn property_matches(filter: &PropertyFilter, ctx: &FeatureFlagContext) -> bool {
+fn property_matches(
+    filter: &PropertyFilter,
+    ctx: &FeatureFlagContext,
+    flag_group_type: Option<&str>,
+) -> bool {
     let property_type = filter.property_type.as_deref().unwrap_or("person");
     let operator = filter.operator.as_deref().unwrap_or("eq");
-    let actual = match property_type {
-        "group" => {
-            let Some(group_type) = filter.group_type.as_ref() else {
-                return false;
-            };
-            let Some(group_props) = ctx.group_properties.get(group_type) else {
-                return false;
-            };
-            group_props.get(&filter.key)
+    let actual = if let Some(group_type) = flag_group_type {
+        ctx.group_properties
+            .get(group_type)
+            .and_then(|group_props| group_props.get(&filter.key))
+    } else {
+        match property_type {
+            "group" => {
+                let Some(group_type) = filter.group_type.as_ref() else {
+                    return false;
+                };
+                let Some(group_props) = ctx.group_properties.get(group_type) else {
+                    return false;
+                };
+                group_props.get(&filter.key)
+            }
+            _ => ctx.person_properties.get(&filter.key),
         }
-        _ => ctx.person_properties.get(&filter.key),
     };
 
     match operator {
-        "is_set" => matches!(actual, Some(value) if !value.is_null()),
+        "is_set" => actual.is_some(),
+        "is_not_set" => false,
         "is_not" => match actual {
             Some(value) => !values_equal(value, &filter.value),
             None => false,
@@ -512,12 +640,32 @@ fn property_matches(filter: &PropertyFilter, ctx: &FeatureFlagContext) -> bool {
             Some(value) => value_contains(value, &filter.value),
             None => false,
         },
+        "icontains" => match actual {
+            Some(value) => value_contains_case_insensitive(value, &filter.value),
+            None => false,
+        },
+        "not_contains" => match actual {
+            Some(value) => !value_contains(value, &filter.value),
+            None => false,
+        },
+        "not_icontains" => match actual {
+            Some(value) => !value_contains_case_insensitive(value, &filter.value),
+            None => false,
+        },
         "regex" => match actual {
             Some(value) => value_regex(value, &filter.value),
             None => false,
         },
+        "not_regex" => match actual {
+            Some(value) => value_not_regex(value, &filter.value),
+            None => false,
+        },
         "gt" | "gte" | "lt" | "lte" => match actual {
             Some(value) => compare_numbers(value, &filter.value, operator),
+            None => false,
+        },
+        "eq" | "exact" | "is" => match actual {
+            Some(value) => values_equal(value, &filter.value),
             None => false,
         },
         _ => match actual {
@@ -528,11 +676,20 @@ fn property_matches(filter: &PropertyFilter, ctx: &FeatureFlagContext) -> bool {
 }
 
 fn values_equal(actual: &Value, expected: &Value) -> bool {
+    if let Value::Array(items) = expected {
+        return items.iter().any(|item| values_equal(actual, item));
+    }
+
+    if let (Some(actual_str), Some(expected_str)) = (actual.as_str(), expected.as_str()) {
+        return actual_str.to_lowercase() == expected_str.to_lowercase();
+    }
+
     if actual == expected {
         return true;
     }
 
-    if let (Some(actual_num), Some(expected_num)) = (coerce_number(actual), coerce_number(expected)) {
+    if let (Some(actual_num), Some(expected_num)) = (coerce_number(actual), coerce_number(expected))
+    {
         return (actual_num - expected_num).abs() < f64::EPSILON;
     }
 
@@ -560,7 +717,21 @@ fn value_contains(actual: &Value, expected: &Value) -> bool {
         (Value::String(actual_str), Value::String(expected_str)) => {
             actual_str.contains(expected_str)
         }
-        (Value::Array(actual_list), _) => actual_list.iter().any(|item| values_equal(item, expected)),
+        (Value::Array(actual_list), _) => {
+            actual_list.iter().any(|item| values_equal(item, expected))
+        }
+        _ => false,
+    }
+}
+
+fn value_contains_case_insensitive(actual: &Value, expected: &Value) -> bool {
+    match (actual, expected) {
+        (Value::String(actual_str), Value::String(expected_str)) => actual_str
+            .to_lowercase()
+            .contains(&expected_str.to_lowercase()),
+        (Value::Array(actual_list), _) => actual_list.iter().any(|item| {
+            values_equal(item, expected) || value_contains_case_insensitive(item, expected)
+        }),
         _ => false,
     }
 }
@@ -578,8 +749,22 @@ fn value_regex(actual: &Value, expected: &Value) -> bool {
     re.is_match(actual_str)
 }
 
+fn value_not_regex(actual: &Value, expected: &Value) -> bool {
+    let Some(actual_str) = actual.as_str() else {
+        return false;
+    };
+    let Some(pattern) = expected.as_str() else {
+        return false;
+    };
+    let Ok(re) = regex::Regex::new(pattern) else {
+        return false;
+    };
+    !re.is_match(actual_str)
+}
+
 fn compare_numbers(actual: &Value, expected: &Value, operator: &str) -> bool {
-    let (Some(actual_num), Some(expected_num)) = (coerce_number(actual), coerce_number(expected)) else {
+    let (Some(actual_num), Some(expected_num)) = (coerce_number(actual), coerce_number(expected))
+    else {
         return false;
     };
     match operator {
@@ -650,9 +835,21 @@ mod tests {
                     ]
                 },
                 {
+                    "key": "exact_case_insensitive",
+                    "conditions": [
+                        { "properties": [{ "key": "plan", "value": "PRO", "operator": "exact" }] }
+                    ]
+                },
+                {
                     "key": "regex",
                     "conditions": [
                         { "properties": [{ "key": "email", "value": ".*@example\\.com$", "operator": "regex" }] }
+                    ]
+                },
+                {
+                    "key": "not_regex",
+                    "conditions": [
+                        { "properties": [{ "key": "email", "value": ".*@other\\.com$", "operator": "not_regex" }] }
                     ]
                 },
                 {
@@ -674,7 +871,10 @@ mod tests {
         let store = FeatureFlagStore::from_json(&flags).expect("valid flag json");
         let mut props = serde_json::Map::new();
         props.insert("plan".to_string(), Value::String("pro".to_string()));
-        props.insert("email".to_string(), Value::String("test@example.com".to_string()));
+        props.insert(
+            "email".to_string(),
+            Value::String("test@example.com".to_string()),
+        );
         props.insert("age".to_string(), Value::String("21".to_string()));
 
         let ctx = context_with_props(props);
@@ -684,7 +884,12 @@ mod tests {
         assert_eq!(values.get("is_not"), Some(&Value::Bool(true)));
         assert_eq!(values.get("in_list"), Some(&Value::Bool(true)));
         assert_eq!(values.get("contains"), Some(&Value::Bool(true)));
+        assert_eq!(
+            values.get("exact_case_insensitive"),
+            Some(&Value::Bool(true))
+        );
         assert_eq!(values.get("regex"), Some(&Value::Bool(true)));
+        assert_eq!(values.get("not_regex"), Some(&Value::Bool(true)));
         assert_eq!(values.get("is_set"), Some(&Value::Bool(true)));
         assert_eq!(values.get("gte_number"), Some(&Value::Bool(true)));
     }
@@ -715,6 +920,105 @@ mod tests {
         let (values, _) = eval.to_maps(2);
         assert!(values.contains_key("alpha"));
         assert!(!values.contains_key("beta"));
+    }
+
+    #[test]
+    fn posthog_hashing_matches_sdk_formula() {
+        let bucket = bucket_for("rollout", "user-1", "");
+        assert!((bucket - 90.21559633337509).abs() < f64::EPSILON);
+
+        let variant_bucket = bucket_for("multi", "user-1", "variant");
+        assert!((variant_bucket - 33.73287381849952).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn official_posthog_definition_shape_is_normalized() {
+        let flags = json!({
+            "group_type_mapping": { "0": "company" },
+            "flags": [
+                {
+                    "key": "official-person",
+                    "active": true,
+                    "filters": {
+                        "groups": [
+                            {
+                                "properties": [
+                                    { "key": "plan", "value": "pro", "type": "person", "operator": "exact" }
+                                ],
+                                "rollout_percentage": 100
+                            }
+                        ],
+                        "payloads": { "true": "{\"tier\":\"pro\"}" }
+                    }
+                },
+                {
+                    "key": "official-variant",
+                    "active": true,
+                    "filters": {
+                        "groups": [
+                            { "properties": [], "rollout_percentage": 100 }
+                        ],
+                        "multivariate": {
+                            "variants": [
+                                { "key": "control", "rollout_percentage": 0 },
+                                { "key": "test", "rollout_percentage": 100 }
+                            ]
+                        },
+                        "payloads": { "test": "{\"copy\":\"new\"}" }
+                    }
+                },
+                {
+                    "key": "official-group",
+                    "active": true,
+                    "filters": {
+                        "aggregation_group_type_index": 0,
+                        "groups": [
+                            {
+                                "properties": [
+                                    { "key": "plan", "value": "enterprise", "type": "group", "operator": "exact" }
+                                ],
+                                "rollout_percentage": 100
+                            }
+                        ],
+                        "payloads": { "true": "group-on" }
+                    }
+                }
+            ]
+        })
+        .to_string();
+
+        let store = FeatureFlagStore::from_json(&flags).expect("valid flag json");
+        let mut person_properties = serde_json::Map::new();
+        person_properties.insert("plan".to_string(), Value::String("pro".to_string()));
+
+        let mut groups = HashMap::new();
+        groups.insert("company".to_string(), "acme".to_string());
+
+        let mut company_properties = serde_json::Map::new();
+        company_properties.insert("plan".to_string(), Value::String("enterprise".to_string()));
+
+        let mut group_properties = HashMap::new();
+        group_properties.insert("company".to_string(), company_properties);
+
+        let ctx = FeatureFlagContext {
+            distinct_id: "user-1".to_string(),
+            person_properties,
+            groups,
+            group_properties,
+        };
+
+        let eval = store.evaluate(&ctx);
+        let (values, payloads) = eval.to_maps(2);
+
+        assert_eq!(values.get("official-person"), Some(&Value::Bool(true)));
+        assert_eq!(payloads["official-person"]["tier"], "pro");
+        assert_eq!(
+            values.get("official-variant"),
+            Some(&Value::String("test".to_string()))
+        );
+        assert_eq!(payloads["official-variant"]["copy"], "new");
+        assert_eq!(values.get("official-group"), Some(&Value::Bool(true)));
+        assert_eq!(payloads["official-group"], "group-on");
     }
 
     #[test]

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -4,6 +4,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::Map;
 use thiserror::Error;
 
+#[cfg(not(target_arch = "wasm32"))]
+use std::collections::HashMap;
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::sync::RwLock;
+
 #[cfg(target_arch = "wasm32")]
 use worker::{Env, Headers, Method, Request, RequestInit, Response, State};
 
@@ -93,6 +98,49 @@ impl GroupStore for NoopGroupStore {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+pub struct MemoryGroupStore {
+    records: RwLock<HashMap<(String, String), GroupRecord>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl MemoryGroupStore {
+    pub fn new() -> Self {
+        Self {
+            records: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait]
+impl GroupStore for MemoryGroupStore {
+    async fn apply_update(&self, update: GroupUpdate) -> Result<GroupSnapshot, GroupError> {
+        let key = (update.group_type.clone(), update.group_key.clone());
+        let mut records = self.records.write().await;
+        let record = records
+            .entry(key)
+            .or_insert_with(|| GroupRecord::new(update.group_type, update.group_key));
+        record.apply_update(&update.properties);
+        Ok(GroupSnapshot {
+            record: Some(record.clone()),
+        })
+    }
+
+    async fn get_snapshot(
+        &self,
+        group_type: &str,
+        group_key: &str,
+    ) -> Result<GroupSnapshot, GroupError> {
+        let records = self.records.read().await;
+        Ok(GroupSnapshot {
+            record: records
+                .get(&(group_type.to_string(), group_key.to_string()))
+                .cloned(),
+        })
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct GroupTypeMap {
     types: [Option<String>; 5],
@@ -112,6 +160,11 @@ impl GroupTypeMap {
     pub fn types(&self) -> &[Option<String>; 5] {
         &self.types
     }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+fn group_object_name(group_type: &str, group_key: &str) -> Result<String, serde_json::Error> {
+    serde_json::to_string(&(group_type, group_key))
 }
 
 impl Default for GroupTypeMap {
@@ -148,8 +201,7 @@ mod durable {
 
             match (method, path.as_str()) {
                 (Method::Get, "/record") => {
-                    let record: Option<GroupRecord> =
-                        self.state.storage().get(RECORD_KEY).await?;
+                    let record: Option<GroupRecord> = self.state.storage().get(RECORD_KEY).await?;
                     Response::from_json(&record)
                 }
                 (Method::Post, "/apply") => {
@@ -185,7 +237,7 @@ mod durable {
             group_type: &str,
             group_key: &str,
         ) -> Result<worker::durable::Stub, GroupError> {
-            let name = format!("{group_type}:{group_key}");
+            let name = group_object_name(group_type, group_key)?;
             let id = self.namespace.id_from_name(&name)?;
             Ok(id.get_stub()?)
         }
@@ -218,9 +270,8 @@ mod durable {
             let status = response.status_code();
             let body_text = response.text().await.unwrap_or_default();
             if !(200..300).contains(&status) {
-                let message = format!(
-                    "durable object {path} failed with status {status}: {body_text}"
-                );
+                let message =
+                    format!("durable object {path} failed with status {status}: {body_text}");
                 worker::console_error!("{message}");
                 return Err(GroupError::Message(message));
             }
@@ -282,3 +333,15 @@ pub use durable::store_from_env;
 
 #[cfg(target_arch = "wasm32")]
 pub use durable::GroupDurableObject;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn durable_group_names_do_not_collide_on_colons() {
+        let left = group_object_name("a:b", "c").unwrap();
+        let right = group_object_name("a", "b:c").unwrap();
+        assert_ne!(left, right);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ pub mod extractors;
 pub mod feature_flags;
 pub mod groups;
 pub mod models;
-pub mod pipeline;
 pub mod persons;
+pub mod pipeline;
 
 use std::sync::Arc;
 
@@ -16,33 +16,33 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-#[cfg(not(target_arch = "wasm32"))]
-use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
-#[cfg(not(target_arch = "wasm32"))]
-use tracing::Level;
+use chrono::Utc;
 use config::{Config, ConfigError};
 use extractors::{
-    header_api_key, header_sent_at, verify_signature, PostHogBatchPayload, PostHogPayload,
-    RequestEnrichment,
+    header_api_key, header_sent_at, verify_signature, ApplyApiKey, PostHogBatchPayload,
+    PostHogPayload, RequestEnrichment,
 };
 use feature_flags::{FeatureFlagContext, FeatureFlagStore};
+use groups::{GroupError, GroupStore, GroupTypeMap, NoopGroupStore};
 use models::{
     AliasRequest, BatchRequest, CaptureRequest, DecideResponse, DecideSessionRecording,
     EngageRequest, ErrorResponse, GroupIdentifyRequest, IdentifyRequest, PostHogResponse,
 };
-use pipeline::{PipelineClient, PipelineError, PipelineEvent};
-use groups::{GroupError, GroupStore, GroupTypeMap, NoopGroupStore};
 use persons::{
     alias_from_request, update_from_capture, update_from_engage, update_from_identify,
     NoopPersonStore, PersonAlias, PersonError, PersonStore, PersonUpdate,
 };
+use pipeline::{PipelineClient, PipelineError, PipelineEvent};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use thiserror::Error;
-use tracing::{error, warn};
+#[cfg(not(target_arch = "wasm32"))]
+use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 #[cfg(not(target_arch = "wasm32"))]
 use tracing::info;
-use chrono::Utc;
+#[cfg(not(target_arch = "wasm32"))]
+use tracing::Level;
+use tracing::{error, warn};
 
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::net::TcpListener;
@@ -215,8 +215,7 @@ pub async fn fetch(
         }
     };
 
-    let person_store: Arc<dyn PersonStore> =
-        persons::store_from_env(&env, config.posthog_team_id);
+    let person_store: Arc<dyn PersonStore> = persons::store_from_env(&env, config.posthog_team_id);
     let group_store: Arc<dyn GroupStore> = groups::store_from_env(&env);
     let group_type_map = GroupTypeMap::new(config.posthog_group_types.clone());
     let feature_flags = Arc::new(config.feature_flags);
@@ -414,6 +413,24 @@ async fn capture(
     let mut events = Vec::new();
 
     for item in payload.items {
+        if item.event == "$groupidentify" {
+            let group_req = group_identify_from_capture(item)?;
+            let snapshot = state
+                .group_store
+                .apply_update(group_update_from_identify(&group_req))
+                .await?;
+            let (group_slots, group_properties) =
+                group_fields_from_snapshot(&state.group_type_map, snapshot);
+            events.push(
+                PipelineEvent::from_group_identify(group_req)
+                    .with_team_id(state.posthog_team_id)
+                    .with_groups(group_slots, group_properties)
+                    .with_sent_at(sent_at.clone())
+                    .with_enrichment(enrichment),
+            );
+            continue;
+        }
+
         let update = update_from_capture(&item);
         let snapshot = match update {
             Some(update) => apply_person_update(&state, update).await?,
@@ -497,183 +514,187 @@ struct BrowserCaptureRequest {
     #[serde(rename = "$set_once")]
     #[serde(default)]
     set_once: Option<Value>,
+    #[serde(default)]
+    #[serde(flatten)]
+    extra: std::collections::HashMap<String, Value>,
+}
+
+impl ApplyApiKey for BrowserCaptureRequest {
+    fn ensure_api_key(&mut self, api_key: &str) {
+        if self.token.is_none() && self.api_key.is_none() {
+            self.api_key = Some(api_key.to_string());
+        }
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", worker::send)]
 async fn browser_capture(
     State(state): State<AppState>,
     enrichment: RequestEnrichment,
-    headers: HeaderMap,
-    body: Bytes,
+    payload: PostHogPayload<BrowserCaptureRequest>,
 ) -> Result<Json<PostHogResponse>, AppError> {
-    let sent_at = header_sent_at(&headers);
+    let sent_at = payload.sent_at.clone();
     let enrichment = enrichment.properties();
+    let mut events = Vec::new();
 
-    let payload: BrowserCaptureRequest =
-        serde_json::from_slice(&body).map_err(|e| AppError::InvalidPayload(e.to_string()))?;
+    for payload in payload.items {
+        let api_key = payload.token.clone().or(payload.api_key.clone());
 
-    let api_key = payload.token.or(payload.api_key).or_else(|| header_api_key(&headers));
+        let distinct_id = browser_distinct_id(&payload)
+            .ok_or_else(|| AppError::InvalidPayload("missing distinct_id".into()))?;
 
-    // Extract distinct_id from payload or properties
-    let distinct_id = payload.distinct_id.clone().or_else(|| {
-        payload.properties.as_ref().and_then(|props| {
-            props
-                .get("$distinct_id")
-                .or_else(|| props.get("distinct_id"))
-                .and_then(Value::as_str)
-                .map(String::from)
-        })
-    });
-
-    let distinct_id =
-        distinct_id.ok_or_else(|| AppError::InvalidPayload("missing distinct_id".into()))?;
-
-    // Handle $identify events specially - use top-level $set as person_properties
-    let event = if payload.event == "$identify" {
-        let mut extra = std::collections::HashMap::new();
-        if let Some(set_once) = payload.set_once.clone() {
-            extra.insert("$set_once".to_string(), set_once);
-        }
-
-        let identify_req = IdentifyRequest {
-            api_key,
-            distinct_id,
-            anon_distinct_id: None,
-            properties: payload.set.clone(),
-            timestamp: payload.timestamp,
-            context: None,
-            extra,
-        };
-        PipelineEvent::from_identify(identify_req)
-    } else if payload.event == "$groupidentify" {
-        // Handle group identify - extract group_type and group_key from $set
-        let props = payload.properties.as_ref();
-        let group_type = props
-            .and_then(|p| p.get("$group_type").and_then(Value::as_str))
-            .unwrap_or("unknown")
-            .to_string();
-        let group_key = props
-            .and_then(|p| p.get("$group_key").and_then(Value::as_str))
-            .unwrap_or("unknown")
-            .to_string();
-        let group_properties = props.and_then(|p| p.get("$group_set").cloned());
-
-        let group_req = GroupIdentifyRequest {
-            api_key,
-            group_type,
-            group_key,
-            properties: group_properties,
-            timestamp: payload.timestamp,
-            extra: std::collections::HashMap::new(),
-        };
-        PipelineEvent::from_group_identify(group_req)
-    } else {
-        let capture_req = CaptureRequest {
-            api_key,
-            event: payload.event,
-            distinct_id,
-            properties: payload.properties,
-            timestamp: payload.timestamp,
-            context: None,
-            extra: std::collections::HashMap::new(),
-        };
-        PipelineEvent::from_capture(capture_req)
-    };
-
-    let mut group_slots = [None, None, None, None, None];
-    let mut group_properties = None;
-
-    if event.event == "$groupidentify" {
-        if let Some(group_type) = event.extra.get("group_type").and_then(Value::as_str) {
-            if let Some(group_key) = event.extra.get("group_key").and_then(Value::as_str) {
-                if let Some(index) = state.group_type_map.index_for(group_type) {
-                    group_slots[index] = Some(group_key.to_string());
-                }
-                let snapshot = state.group_store.get_snapshot(group_type, group_key).await?;
-                if let Some(record) = snapshot.record {
-                    let mut props = serde_json::Map::new();
-                    props.insert(record.group_type.clone(), Value::Object(record.properties));
-                    group_properties = Some(Value::Object(props));
+        let event = if payload.event == "$identify" {
+            let identify_req = browser_identify_request(payload, api_key, distinct_id);
+            if let Some(anon) = identify_req
+                .anon_distinct_id
+                .clone()
+                .or_else(|| {
+                    identify_req
+                        .properties
+                        .as_ref()
+                        .and_then(Value::as_object)
+                        .and_then(|props| props.get("$anon_distinct_id"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+                .or_else(|| {
+                    identify_req
+                        .extra
+                        .get("$anon_distinct_id")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+            {
+                if anon != identify_req.distinct_id {
+                    state
+                        .person_store
+                        .apply_alias(PersonAlias {
+                            distinct_id: identify_req.distinct_id.clone(),
+                            alias: anon,
+                        })
+                        .await?;
                 }
             }
-        }
-    } else {
-        let groups = extract_groups(&event.properties);
-        let group_set = if let Some(Value::Object(props)) = event.properties.as_ref() {
-            extract_group_set(props.get("$group_set"))
+            PipelineEvent::from_identify(identify_req)
+        } else if payload.event == "$groupidentify" {
+            let group_req = browser_group_identify_request(payload, api_key)?;
+            let group_update = group_update_from_identify(&group_req);
+            state.group_store.apply_update(group_update).await?;
+            PipelineEvent::from_group_identify(group_req)
         } else {
-            serde_json::Map::new()
+            let capture_req = CaptureRequest {
+                api_key,
+                event: payload.event,
+                distinct_id,
+                properties: payload.properties,
+                timestamp: payload.timestamp,
+                context: None,
+                extra: payload.extra,
+            };
+            PipelineEvent::from_capture(capture_req)
         };
 
-        if let Some(groups_map) = groups.as_ref() {
-            for (group_type, props) in &group_set {
-                let Some(group_key) = groups_map.get(group_type).and_then(Value::as_str) else {
-                    continue;
-                };
-                let Some(props_map) = props.as_object() else {
-                    continue;
-                };
-                if props_map.is_empty() {
-                    continue;
-                }
-                state
-                    .group_store
-                    .apply_update(groups::GroupUpdate {
-                        group_type: group_type.clone(),
-                        group_key: group_key.to_string(),
-                        properties: props_map.clone(),
-                    })
-                    .await?;
-            }
+        let mut group_slots = [None, None, None, None, None];
+        let mut group_properties = None;
 
-            group_slots = group_slots_from_map(&state.group_type_map, groups_map);
-            group_properties = hydrate_group_properties(&state, groups_map).await?;
+        if event.event == "$groupidentify" {
+            if let Some(group_type) = event.extra.get("group_type").and_then(Value::as_str) {
+                if let Some(group_key) = event.extra.get("group_key").and_then(Value::as_str) {
+                    if let Some(index) = state.group_type_map.index_for(group_type) {
+                        group_slots[index] = Some(group_key.to_string());
+                    }
+                    let snapshot = state
+                        .group_store
+                        .get_snapshot(group_type, group_key)
+                        .await?;
+                    if let Some(record) = snapshot.record {
+                        let mut props = serde_json::Map::new();
+                        props.insert(record.group_type.clone(), Value::Object(record.properties));
+                        group_properties = Some(Value::Object(props));
+                    }
+                }
+            }
+        } else {
+            let groups = extract_groups(&event.properties);
+            let group_set = if let Some(Value::Object(props)) = event.properties.as_ref() {
+                extract_group_set(props.get("$group_set"))
+            } else {
+                serde_json::Map::new()
+            };
+
+            if let Some(groups_map) = groups.as_ref() {
+                for (group_type, props) in &group_set {
+                    let Some(group_key) = groups_map.get(group_type).and_then(Value::as_str) else {
+                        continue;
+                    };
+                    let Some(props_map) = props.as_object() else {
+                        continue;
+                    };
+                    if props_map.is_empty() {
+                        continue;
+                    }
+                    state
+                        .group_store
+                        .apply_update(groups::GroupUpdate {
+                            group_type: group_type.clone(),
+                            group_key: group_key.to_string(),
+                            properties: props_map.clone(),
+                        })
+                        .await?;
+                }
+
+                group_slots = group_slots_from_map(&state.group_type_map, groups_map);
+                group_properties = hydrate_group_properties(&state, groups_map).await?;
+            }
         }
+
+        let snapshot = if event.event == "$groupidentify" {
+            None
+        } else {
+            let update = if event.event == "$identify" {
+                update_from_identify(&IdentifyRequest {
+                    api_key: event.api_key.clone(),
+                    distinct_id: event.distinct_id.clone(),
+                    anon_distinct_id: None,
+                    properties: event.person_properties.clone(),
+                    timestamp: event.timestamp,
+                    context: None,
+                    extra: event.extra.clone(),
+                })
+            } else {
+                update_from_capture(&CaptureRequest {
+                    api_key: event.api_key.clone(),
+                    event: event.event.clone(),
+                    distinct_id: event.distinct_id.clone(),
+                    properties: event.properties.clone(),
+                    timestamp: event.timestamp,
+                    context: None,
+                    extra: event.extra.clone(),
+                })
+            };
+
+            Some(match update {
+                Some(update) => apply_person_update(&state, update).await?,
+                None => ensure_person_snapshot(&state, &event.distinct_id).await?,
+            })
+        };
+
+        let (person_id, person_created_at, person_properties) = snapshot
+            .as_ref()
+            .map(person_fields)
+            .unwrap_or((None, None, None));
+
+        events.push(
+            event
+                .with_team_id(state.posthog_team_id)
+                .with_person(person_id, person_created_at, person_properties)
+                .with_groups(group_slots, group_properties)
+                .with_sent_at(sent_at.clone())
+                .with_enrichment(enrichment),
+        );
     }
 
-    let snapshot = if event.event == "$groupidentify" {
-        None
-    } else {
-        let update = if event.event == "$identify" {
-            update_from_identify(&IdentifyRequest {
-                api_key: event.api_key.clone(),
-                distinct_id: event.distinct_id.clone(),
-                anon_distinct_id: None,
-                properties: event.person_properties.clone(),
-                timestamp: event.timestamp,
-                context: None,
-                extra: event.extra.clone(),
-            })
-        } else {
-            update_from_capture(&CaptureRequest {
-                api_key: event.api_key.clone(),
-                event: event.event.clone(),
-                distinct_id: event.distinct_id.clone(),
-                properties: event.properties.clone(),
-                timestamp: event.timestamp,
-                context: None,
-                extra: event.extra.clone(),
-            })
-        };
-
-        Some(match update {
-            Some(update) => apply_person_update(&state, update).await?,
-            None => ensure_person_snapshot(&state, &event.distinct_id).await?,
-        })
-    };
-
-    let (person_id, person_created_at, person_properties) = snapshot
-        .as_ref()
-        .map(person_fields)
-        .unwrap_or((None, None, None));
-
-    let event = event
-        .with_team_id(state.posthog_team_id)
-        .with_person(person_id, person_created_at, person_properties)
-        .with_groups(group_slots, group_properties)
-        .with_sent_at(sent_at)
-        .with_enrichment(enrichment);
-    state.pipeline.send(vec![event]).await?;
+    state.pipeline.send(events).await?;
     Ok(Json(PostHogResponse::success()))
 }
 
@@ -758,8 +779,7 @@ async fn batch(
     let sent_at = payload.batch.sent_at.clone();
     let shared_api_key = payload.batch.api_key.clone();
     let enrichment = enrichment.properties();
-    let items = convert_batch(payload.batch, shared_api_key)
-        .map_err(AppError::InvalidPayload)?;
+    let items = convert_batch(payload.batch, shared_api_key).map_err(AppError::InvalidPayload)?;
 
     let mut events = Vec::new();
 
@@ -780,16 +800,8 @@ async fn batch(
 
         if let Some(group_update) = item.group_update {
             let snapshot = state.group_store.apply_update(group_update).await?;
-            let mut group_slots = [None, None, None, None, None];
-            let mut group_properties = None;
-            if let Some(record) = snapshot.record {
-                if let Some(index) = state.group_type_map.index_for(&record.group_type) {
-                    group_slots[index] = Some(record.group_key.clone());
-                }
-                let mut props = serde_json::Map::new();
-                props.insert(record.group_type.clone(), Value::Object(record.properties));
-                group_properties = Some(Value::Object(props));
-            }
+            let (group_slots, group_properties) =
+                group_fields_from_snapshot(&state.group_type_map, snapshot);
 
             let event = item
                 .event
@@ -877,35 +889,13 @@ async fn groups(
     let mut events = Vec::new();
 
     for item in payload.items {
-        let group_update = item
-            .properties
-            .as_ref()
-            .and_then(|value| value.as_object())
-            .map(|props| groups::GroupUpdate {
-                group_type: item.group_type.clone(),
-                group_key: item.group_key.clone(),
-                properties: props.clone(),
-            });
-
-        let snapshot = if let Some(update) = group_update {
-            state.group_store.apply_update(update).await?
-        } else {
-            state
-                .group_store
-                .get_snapshot(&item.group_type, &item.group_key)
-                .await?
-        };
-
-        let mut group_slots = [None, None, None, None, None];
-        let mut group_properties = None;
-        if let Some(record) = snapshot.record {
-            if let Some(index) = state.group_type_map.index_for(&record.group_type) {
-                group_slots[index] = Some(record.group_key.clone());
-            }
-            let mut props = serde_json::Map::new();
-            props.insert(record.group_type.clone(), Value::Object(record.properties));
-            group_properties = Some(Value::Object(props));
-        }
+        let item = normalize_group_identify_request(item)?;
+        let snapshot = state
+            .group_store
+            .apply_update(group_update_from_identify(&item))
+            .await?;
+        let (group_slots, group_properties) =
+            group_fields_from_snapshot(&state.group_type_map, snapshot);
 
         events.push(
             PipelineEvent::from_group_identify(item)
@@ -1033,13 +1023,24 @@ struct DecideRequest {
     #[serde(default)]
     person_properties: Option<std::collections::HashMap<String, Value>>,
     #[serde(default, rename = "group_properties")]
-    group_properties: Option<std::collections::HashMap<String, std::collections::HashMap<String, Value>>>,
+    group_properties:
+        Option<std::collections::HashMap<String, std::collections::HashMap<String, Value>>>,
     #[serde(default)]
     disable_flags: Option<bool>,
     #[serde(default)]
     flag_keys_to_evaluate: Option<Vec<String>>,
     #[serde(default)]
     evaluation_environments: Option<Vec<String>>,
+    #[serde(default)]
+    evaluation_contexts: Option<Vec<String>>,
+}
+
+impl ApplyApiKey for DecideRequest {
+    fn ensure_api_key(&mut self, api_key: &str) {
+        if self.api_key.is_none() && self.token.is_none() {
+            self.api_key = Some(api_key.to_string());
+        }
+    }
 }
 
 #[derive(Default, Deserialize)]
@@ -1053,20 +1054,15 @@ struct FlagsQuery {
 #[cfg_attr(target_arch = "wasm32", worker::send)]
 async fn decide(
     State(state): State<AppState>,
-    headers: HeaderMap,
     axum::extract::Query(query): axum::extract::Query<FlagsQuery>,
-    Json(payload): Json<DecideRequest>,
+    payload: PostHogPayload<DecideRequest>,
 ) -> Result<Json<DecideResponse>, AppError> {
-    let header_key = headers
-        .get("x-posthog-api-key")
-        .and_then(|value| value.to_str().ok())
-        .map(|value| value.to_string());
+    let payload = payload.items.into_iter().next().unwrap_or_default();
 
     let api_key = payload
         .api_key
         .clone()
         .or(payload.token.clone())
-        .or(header_key)
         .or(state.decide_api_token.clone());
 
     let version = query.v.unwrap_or(2);
@@ -1110,8 +1106,9 @@ struct FlagsResponse {
 async fn flags(
     State(state): State<AppState>,
     axum::extract::Query(query): axum::extract::Query<FlagsQuery>,
-    Json(payload): Json<DecideRequest>,
+    payload: PostHogPayload<DecideRequest>,
 ) -> Result<impl IntoResponse, AppError> {
+    let payload = payload.items.into_iter().next().unwrap_or_default();
     let version = query.v.unwrap_or(2);
     let flags = evaluate_feature_flags(&state, &payload).await?;
     let (feature_flags, feature_flag_payloads) = flags.to_maps(version);
@@ -1257,7 +1254,11 @@ async fn apply_person_update(
     update: PersonUpdate,
 ) -> Result<persons::PersonSnapshot, AppError> {
     if update.is_empty() {
-        return state.person_store.ensure_person(&update.distinct_id).await.map_err(Into::into);
+        return state
+            .person_store
+            .ensure_person(&update.distinct_id)
+            .await
+            .map_err(Into::into);
     }
     Ok(state.person_store.apply_update(update).await?)
 }
@@ -1306,15 +1307,25 @@ async fn evaluate_feature_flags(
             person_properties.insert(key.clone(), value.clone());
         }
     }
+    person_properties
+        .entry("distinct_id".to_string())
+        .or_insert_with(|| Value::String(distinct_id.clone()));
 
     let groups = payload.groups.clone().unwrap_or_default();
     let mut group_properties: std::collections::HashMap<String, serde_json::Map<String, Value>> =
         std::collections::HashMap::new();
 
     for (group_type, group_key) in &groups {
-        let snapshot = state.group_store.get_snapshot(group_type, group_key).await?;
+        let snapshot = state
+            .group_store
+            .get_snapshot(group_type, group_key)
+            .await?;
         if let Some(record) = snapshot.record {
-            group_properties.insert(group_type.clone(), record.properties);
+            let mut props = record.properties;
+            props
+                .entry("$group_key".to_string())
+                .or_insert_with(|| Value::String(group_key.clone()));
+            group_properties.insert(group_type.clone(), props);
         }
     }
 
@@ -1322,7 +1333,15 @@ async fn evaluate_feature_flags(
         for (group_type, props) in overrides {
             let converted: serde_json::Map<String, Value> =
                 props.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-            group_properties.insert(group_type.clone(), converted);
+            let merged = group_properties.entry(group_type.clone()).or_default();
+            for (key, value) in converted {
+                merged.insert(key, value);
+            }
+            if let Some(group_key) = groups.get(group_type) {
+                merged
+                    .entry("$group_key".to_string())
+                    .or_insert_with(|| Value::String(group_key.clone()));
+            }
         }
     }
 
@@ -1340,13 +1359,20 @@ async fn evaluate_feature_flags(
     if let Some(envs) = payload.evaluation_environments.as_ref() {
         options.evaluation_environments = Some(envs.iter().cloned().collect());
     }
+    if let Some(contexts) = payload.evaluation_contexts.as_ref() {
+        options.evaluation_environments = Some(contexts.iter().cloned().collect());
+    }
 
     Ok(state.feature_flags.evaluate_with(&ctx, &options))
 }
 
 fn person_fields(
     snapshot: &persons::PersonSnapshot,
-) -> (Option<String>, Option<chrono::DateTime<chrono::Utc>>, Option<Value>) {
+) -> (
+    Option<String>,
+    Option<chrono::DateTime<chrono::Utc>>,
+    Option<Value>,
+) {
     match &snapshot.record {
         Some(record) => (
             Some(record.uuid.clone()),
@@ -1361,6 +1387,177 @@ fn extract_groups(properties: &Option<Value>) -> Option<serde_json::Map<String, 
     let props = properties.as_ref()?.as_object()?;
     let groups = props.get("$groups")?.as_object()?;
     Some(groups.clone())
+}
+
+fn browser_distinct_id(payload: &BrowserCaptureRequest) -> Option<String> {
+    payload.distinct_id.clone().or_else(|| {
+        payload.properties.as_ref().and_then(|props| {
+            props
+                .get("$distinct_id")
+                .or_else(|| props.get("distinct_id"))
+                .and_then(Value::as_str)
+                .map(String::from)
+        })
+    })
+}
+
+fn browser_identify_request(
+    payload: BrowserCaptureRequest,
+    api_key: Option<String>,
+    distinct_id: String,
+) -> IdentifyRequest {
+    let mut extra = payload.extra;
+    let properties_obj = payload.properties.as_ref().and_then(Value::as_object);
+
+    let set = payload.set.or_else(|| {
+        properties_obj
+            .and_then(|props| props.get("$set"))
+            .cloned()
+            .or(payload.properties.clone())
+    });
+
+    if let Some(set_once) = payload.set_once.or_else(|| {
+        properties_obj
+            .and_then(|props| props.get("$set_once"))
+            .cloned()
+    }) {
+        extra.insert("$set_once".to_string(), set_once);
+    }
+
+    let anon_distinct_id = properties_obj
+        .and_then(|props| props.get("$anon_distinct_id"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            extra
+                .get("$anon_distinct_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        });
+
+    IdentifyRequest {
+        api_key,
+        distinct_id,
+        anon_distinct_id,
+        properties: set,
+        timestamp: payload.timestamp,
+        context: None,
+        extra,
+    }
+}
+
+fn browser_group_identify_request(
+    payload: BrowserCaptureRequest,
+    api_key: Option<String>,
+) -> Result<GroupIdentifyRequest, AppError> {
+    group_identify_from_parts(
+        api_key,
+        payload.properties,
+        payload.timestamp,
+        payload.extra,
+    )
+}
+
+fn group_identify_from_capture(payload: CaptureRequest) -> Result<GroupIdentifyRequest, AppError> {
+    group_identify_from_parts(
+        payload.api_key,
+        payload.properties,
+        payload.timestamp,
+        payload.extra,
+    )
+}
+
+fn group_identify_from_parts(
+    api_key: Option<String>,
+    properties: Option<Value>,
+    timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    extra: std::collections::HashMap<String, Value>,
+) -> Result<GroupIdentifyRequest, AppError> {
+    let props = properties
+        .as_ref()
+        .and_then(Value::as_object)
+        .ok_or_else(|| AppError::InvalidPayload("missing group identify properties".to_string()))?;
+
+    let group_type = props
+        .get("$group_type")
+        .or_else(|| props.get("group_type"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| AppError::InvalidPayload("missing $group_type".to_string()))?
+        .to_string();
+    let group_key = props
+        .get("$group_key")
+        .or_else(|| props.get("group_key"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| AppError::InvalidPayload("missing $group_key".to_string()))?
+        .to_string();
+    let group_properties = props
+        .get("$group_set")
+        .or_else(|| props.get("properties"))
+        .cloned()
+        .or_else(|| Some(Value::Object(serde_json::Map::new())));
+
+    Ok(GroupIdentifyRequest {
+        api_key,
+        group_type,
+        group_key,
+        properties: group_properties,
+        timestamp,
+        extra,
+    })
+}
+
+fn normalize_group_identify_request(
+    request: GroupIdentifyRequest,
+) -> Result<GroupIdentifyRequest, AppError> {
+    if !request.group_type.is_empty() && !request.group_key.is_empty() {
+        return Ok(request);
+    }
+
+    group_identify_from_parts(
+        request.api_key,
+        request.properties,
+        request.timestamp,
+        request.extra,
+    )
+}
+
+fn group_update_from_identify(request: &GroupIdentifyRequest) -> groups::GroupUpdate {
+    let properties = request
+        .properties
+        .as_ref()
+        .and_then(Value::as_object)
+        .map(|props| {
+            props
+                .get("$group_set")
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_else(|| props.clone())
+        })
+        .unwrap_or_default();
+
+    groups::GroupUpdate {
+        group_type: request.group_type.clone(),
+        group_key: request.group_key.clone(),
+        properties,
+    }
+}
+
+fn group_fields_from_snapshot(
+    group_type_map: &GroupTypeMap,
+    snapshot: groups::GroupSnapshot,
+) -> ([Option<String>; 5], Option<Value>) {
+    let mut group_slots = [None, None, None, None, None];
+    let mut group_properties = None;
+    if let Some(record) = snapshot.record {
+        if let Some(index) = group_type_map.index_for(&record.group_type) {
+            group_slots[index] = Some(record.group_key.clone());
+        }
+        let mut props = serde_json::Map::new();
+        props.insert(record.group_type.clone(), Value::Object(record.properties));
+        group_properties = Some(Value::Object(props));
+    }
+
+    (group_slots, group_properties)
 }
 
 fn extract_group_set(value: Option<&Value>) -> serde_json::Map<String, Value> {
@@ -1396,8 +1593,13 @@ async fn hydrate_group_properties(
 ) -> Result<Option<Value>, AppError> {
     let mut props = serde_json::Map::new();
     for (group_type, value) in groups {
-        let Some(group_key) = value.as_str() else { continue };
-        let snapshot = state.group_store.get_snapshot(group_type, group_key).await?;
+        let Some(group_key) = value.as_str() else {
+            continue;
+        };
+        let snapshot = state
+            .group_store
+            .get_snapshot(group_type, group_key)
+            .await?;
         if let Some(record) = snapshot.record {
             props.insert(group_type.clone(), Value::Object(record.properties));
         }
@@ -1442,6 +1644,96 @@ fn convert_batch(
     }
 
     Ok(items)
+}
+
+fn normalize_capture_value(mut value: Value) -> Result<Value, String> {
+    let map = value
+        .as_object_mut()
+        .ok_or_else(|| "expected JSON object in batch payload".to_string())?;
+    if map.get("distinct_id").is_none() {
+        if let Some(distinct_id) = map
+            .get("properties")
+            .and_then(Value::as_object)
+            .and_then(|props| {
+                props
+                    .get("distinct_id")
+                    .or_else(|| props.get("$distinct_id"))
+                    .and_then(Value::as_str)
+            })
+            .map(str::to_string)
+        {
+            map.insert("distinct_id".to_string(), Value::String(distinct_id));
+        }
+    }
+    Ok(value)
+}
+
+fn normalize_alias_value(mut value: Value) -> Result<Value, String> {
+    let map = value
+        .as_object_mut()
+        .ok_or_else(|| "expected JSON object in batch alias payload".to_string())?;
+    if map.get("alias").is_none() {
+        if let Some(alias) = map
+            .get("properties")
+            .and_then(Value::as_object)
+            .and_then(|props| props.get("alias").and_then(Value::as_str))
+            .map(str::to_string)
+        {
+            map.insert("alias".to_string(), Value::String(alias));
+        }
+    }
+    Ok(value)
+}
+
+fn normalize_group_identify_value(mut value: Value) -> Result<Value, String> {
+    let map = value
+        .as_object_mut()
+        .ok_or_else(|| "expected JSON object in batch group identify payload".to_string())?;
+    let props = map.get("properties").and_then(Value::as_object).cloned();
+
+    if map.get("group_type").is_none() {
+        if let Some(group_type) = props
+            .as_ref()
+            .and_then(|props| {
+                props
+                    .get("$group_type")
+                    .or_else(|| props.get("group_type"))
+                    .and_then(Value::as_str)
+            })
+            .map(str::to_string)
+        {
+            map.insert("group_type".to_string(), Value::String(group_type));
+        }
+    }
+
+    if map.get("group_key").is_none() {
+        if let Some(group_key) = props
+            .as_ref()
+            .and_then(|props| {
+                props
+                    .get("$group_key")
+                    .or_else(|| props.get("group_key"))
+                    .and_then(Value::as_str)
+            })
+            .map(str::to_string)
+        {
+            map.insert("group_key".to_string(), Value::String(group_key));
+        }
+    }
+
+    if let Some(group_set) = props
+        .as_ref()
+        .and_then(|props| props.get("$group_set").cloned())
+    {
+        map.insert("properties".to_string(), group_set);
+    } else if map.get("properties").is_none() {
+        map.insert(
+            "properties".to_string(),
+            Value::Object(serde_json::Map::new()),
+        );
+    }
+
+    Ok(value)
 }
 
 fn convert_batch_item(
@@ -1498,17 +1790,10 @@ fn convert_batch_item(
         || matches!(type_field.as_deref(), Some("group_identify"))
         || matches!(event_field.as_deref(), Some("$groupidentify"))
     {
+        let value = normalize_group_identify_value(value)?;
         return serde_json::from_value::<GroupIdentifyRequest>(value)
             .map(|request| {
-                let group_update = request
-                    .properties
-                    .as_ref()
-                    .and_then(|value| value.as_object())
-                    .map(|props| groups::GroupUpdate {
-                        group_type: request.group_type.clone(),
-                        group_key: request.group_key.clone(),
-                        properties: props.clone(),
-                    });
+                let group_update = Some(group_update_from_identify(&request));
                 BatchItem {
                     kind: BatchItemKind::GroupIdentify,
                     event: PipelineEvent::from_group_identify(request),
@@ -1527,6 +1812,7 @@ fn convert_batch_item(
         || matches!(event_field.as_deref(), Some("$create_alias"))
         || has_alias_fields
     {
+        let value = normalize_alias_value(value)?;
         return serde_json::from_value::<AliasRequest>(value)
             .map(|request| {
                 let alias = alias_from_request(&request);
@@ -1568,6 +1854,7 @@ fn convert_batch_item(
             .map_err(|err| format!("invalid engage event: {err}"));
     }
 
+    let value = normalize_capture_value(value)?;
     serde_json::from_value::<CaptureRequest>(value)
         .map(|request| {
             let update = update_from_capture(&request);

--- a/src/models.rs
+++ b/src/models.rs
@@ -104,7 +104,9 @@ pub struct EngageRequest {
 pub struct GroupIdentifyRequest {
     #[serde(default)]
     pub api_key: Option<String>,
+    #[serde(default)]
     pub group_type: String,
+    #[serde(default)]
     pub group_key: String,
     #[serde(default)]
     pub properties: Option<Value>,
@@ -124,7 +126,7 @@ pub struct DecideResponse {
     pub feature_flag_payloads: HashMap<String, Value>,
     pub config: DecideConfig,
     #[serde(rename = "errorsWhileComputingFlags")]
-    pub errors_while_computing_flags: Vec<Value>,
+    pub errors_while_computing_flags: bool,
     #[serde(rename = "sessionRecording")]
     pub session_recording: DecideSessionRecording,
     #[serde(rename = "supportedCompression")]
@@ -138,7 +140,7 @@ impl Default for DecideResponse {
             feature_flags: HashMap::new(),
             feature_flag_payloads: HashMap::new(),
             config: DecideConfig::default(),
-            errors_while_computing_flags: Vec::new(),
+            errors_while_computing_flags: false,
             session_recording: DecideSessionRecording::default(),
             supported_compression: vec!["gzip".to_string(), "gzip-js".to_string()],
         }

--- a/src/persons.rs
+++ b/src/persons.rs
@@ -97,12 +97,12 @@ impl PersonRecord {
         }
 
         for (key, value) in &secondary.properties_set_once {
-            if merged.properties.contains_key(key)
-                || merged.properties_set_once.contains_key(key)
-            {
+            if merged.properties.contains_key(key) || merged.properties_set_once.contains_key(key) {
                 continue;
             }
-            merged.properties_set_once.insert(key.clone(), value.clone());
+            merged
+                .properties_set_once
+                .insert(key.clone(), value.clone());
         }
 
         merged.version = merged.version.saturating_add(1);
@@ -237,8 +237,16 @@ impl MemoryPersonStore {
     async fn resolve_id(&self, distinct_id: &str) -> String {
         let redirects = self.redirects.read().await;
         let mut current = distinct_id.to_string();
+        let mut seen = Vec::new();
         let mut hops = 0;
         while let Some(next) = redirects.get(&current) {
+            if next == &current {
+                return current;
+            }
+            if seen.iter().any(|id| id == &current) {
+                return seen.into_iter().min().unwrap_or(current);
+            }
+            seen.push(current.clone());
             current = next.clone();
             hops += 1;
             if hops > 10 {
@@ -381,8 +389,7 @@ pub fn update_from_capture(request: &CaptureRequest) -> Option<PersonUpdate> {
 pub fn update_from_identify(request: &IdentifyRequest) -> Option<PersonUpdate> {
     let properties = request.properties.as_ref()?;
     let props = properties.as_object()?;
-    let (set, mut set_once) = if props.contains_key("$set") || props.contains_key("$set_once")
-    {
+    let (set, mut set_once) = if props.contains_key("$set") || props.contains_key("$set_once") {
         (
             extract_object(props.get("$set")),
             extract_object(props.get("$set_once")),
@@ -459,12 +466,12 @@ fn extract_unset(value: Option<&Value>) -> Vec<String> {
 mod durable {
     use super::*;
 
+    use worker::wasm_bindgen;
+    use worker::wasm_bindgen::JsValue;
     use worker::{
         durable_object, DurableObject, Env, Headers, Method, ObjectNamespace, Request, RequestInit,
         Response, State,
     };
-    use worker::wasm_bindgen;
-    use worker::wasm_bindgen::JsValue;
 
     const RECORD_KEY: &str = "record";
     const REDIRECT_KEY: &str = "redirect";
@@ -485,6 +492,35 @@ mod durable {
         id: i64,
     }
 
+    #[derive(Serialize, Deserialize)]
+    struct EnsurePersonRequest {
+        distinct_id: String,
+        team_id: Option<i64>,
+        allocated_id: i64,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct ApplyPersonUpdateRequest {
+        update: PersonUpdate,
+        team_id: Option<i64>,
+        allocated_id: i64,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct MergePersonRequest {
+        alias: PersonAliasWire,
+        secondary: Option<PersonRecord>,
+        team_id: Option<i64>,
+        primary_allocated_id: i64,
+        secondary_allocated_id: i64,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct PersonAliasWire {
+        distinct_id: String,
+        alias: String,
+    }
+
     #[durable_object]
     pub struct PersonDurableObject {
         state: State,
@@ -503,25 +539,91 @@ mod durable {
             match (method, path.as_str()) {
                 (Method::Get, "/resolve") => {
                     let redirect: Option<String> = self.state.storage().get(REDIRECT_KEY).await?;
-                    Response::from_json(&ResolveResponse { redirect_to: redirect })
+                    Response::from_json(&ResolveResponse {
+                        redirect_to: redirect,
+                    })
                 }
                 (Method::Get, "/record") => {
                     let record: Option<PersonRecord> = self.state.storage().get(RECORD_KEY).await?;
                     Response::from_json(&record)
                 }
                 (Method::Post, "/apply") => {
-                    let update: PersonUpdate = req.json().await?;
+                    let body: ApplyPersonUpdateRequest = req.json().await?;
+                    let update = body.update;
                     let mut record = self
                         .state
                         .storage()
                         .get::<PersonRecord>(RECORD_KEY)
                         .await?
                         .unwrap_or_else(|| {
-                            PersonRecord::new(update.distinct_id.clone(), None, 0)
+                            PersonRecord::new(
+                                update.distinct_id.clone(),
+                                body.team_id,
+                                body.allocated_id,
+                            )
                         });
+                    if record.id == 0 {
+                        record.id = body.allocated_id;
+                    }
                     record.apply_update(&update);
-                    self.state.storage().put(RECORD_KEY, record).await?;
-                    Response::from_json(&serde_json::json!({ "ok": true }))
+                    self.state.storage().put(RECORD_KEY, &record).await?;
+                    Response::from_json(&record)
+                }
+                (Method::Post, "/ensure") => {
+                    let body: EnsurePersonRequest = req.json().await?;
+                    let existing = self.state.storage().get::<PersonRecord>(RECORD_KEY).await?;
+                    let created = existing.is_none();
+                    let mut record = existing.unwrap_or_else(|| {
+                        PersonRecord::new(body.distinct_id.clone(), body.team_id, body.allocated_id)
+                    });
+                    let mut changed = false;
+                    if record.id == 0 {
+                        record.id = body.allocated_id;
+                        changed = true;
+                    }
+                    if !record.distinct_ids.iter().any(|id| id == &body.distinct_id) {
+                        record.ensure_distinct_id(&body.distinct_id);
+                        changed = true;
+                    }
+                    if changed || created {
+                        self.state.storage().put(RECORD_KEY, &record).await?;
+                    }
+                    Response::from_json(&record)
+                }
+                (Method::Post, "/merge") => {
+                    let body: MergePersonRequest = req.json().await?;
+                    let mut primary_record = self
+                        .state
+                        .storage()
+                        .get::<PersonRecord>(RECORD_KEY)
+                        .await?
+                        .unwrap_or_else(|| {
+                            PersonRecord::new(
+                                body.alias.distinct_id.clone(),
+                                body.team_id,
+                                body.primary_allocated_id,
+                            )
+                        });
+                    if primary_record.id == 0 {
+                        primary_record.id = body.primary_allocated_id;
+                    }
+                    primary_record.ensure_distinct_id(&body.alias.distinct_id);
+
+                    let mut secondary_record = body.secondary.unwrap_or_else(|| {
+                        PersonRecord::new(
+                            body.alias.alias.clone(),
+                            body.team_id,
+                            body.secondary_allocated_id,
+                        )
+                    });
+                    if secondary_record.id == 0 {
+                        secondary_record.id = body.secondary_allocated_id;
+                    }
+                    secondary_record.ensure_distinct_id(&body.alias.alias);
+
+                    let merged = PersonRecord::merge(&primary_record, &secondary_record);
+                    self.state.storage().put(RECORD_KEY, &merged).await?;
+                    Response::from_json(&merged)
                 }
                 (Method::Post, "/set_record") => {
                     let record: PersonRecord = req.json().await?;
@@ -615,25 +717,20 @@ mod durable {
                 init.with_body(Some(JsValue::from_str(&payload)));
             }
 
-            let req = Request::new_with_init(
-                &format!("https://person.internal{path}"),
-                &init,
-            )?;
+            let req = Request::new_with_init(&format!("https://person.internal{path}"), &init)?;
             let mut response = stub.fetch_with_request(req).await?;
             let status = response.status_code();
             let body_text = response.text().await.unwrap_or_default();
             if !(200..300).contains(&status) {
-                let message = format!(
-                    "durable object {path} failed with status {status}: {body_text}"
-                );
+                let message =
+                    format!("durable object {path} failed with status {status}: {body_text}");
                 worker::console_error!("{message}");
                 return Err(PersonError::Message(message));
             }
 
             serde_json::from_str(&body_text).map_err(|err| {
-                let message = format!(
-                    "durable object {path} returned invalid json: {err} ({body_text})"
-                );
+                let message =
+                    format!("durable object {path} returned invalid json: {err} ({body_text})");
                 worker::console_error!("{message}");
                 PersonError::Message(message)
             })
@@ -653,10 +750,30 @@ mod durable {
         }
 
         async fn resolve_id(&self, distinct_id: &str) -> Result<String, PersonError> {
-            let response: ResolveResponse = self
-                .request_json(distinct_id, Method::Get, "/resolve", None::<&()>)
-                .await?;
-            Ok(response.redirect_to.unwrap_or_else(|| distinct_id.to_string()))
+            let mut current = distinct_id.to_string();
+            let mut seen = std::collections::HashSet::new();
+            let mut chain = Vec::new();
+            for _ in 0..10 {
+                if !seen.insert(current.clone()) {
+                    chain.push(current);
+                    return Ok(chain
+                        .into_iter()
+                        .min()
+                        .unwrap_or_else(|| distinct_id.to_string()));
+                }
+                chain.push(current.clone());
+                let response: ResolveResponse = self
+                    .request_json(&current, Method::Get, "/resolve", None::<&()>)
+                    .await?;
+                let Some(next) = response.redirect_to else {
+                    return Ok(current);
+                };
+                if next == current {
+                    return Ok(current);
+                }
+                current = next;
+            }
+            Ok(chain.into_iter().min().unwrap_or(current))
         }
 
         async fn next_person_id(&self) -> Result<i64, PersonError> {
@@ -672,47 +789,28 @@ mod durable {
             let status = response.status_code();
             let body_text = response.text().await.unwrap_or_default();
             if !(200..300).contains(&status) {
-                let message = format!(
-                    "person id counter failed with status {status}: {body_text}"
-                );
+                let message = format!("person id counter failed with status {status}: {body_text}");
                 worker::console_error!("{message}");
                 return Err(PersonError::Message(message));
             }
             serde_json::from_str::<CounterResponse>(&body_text)
                 .map_err(|err| {
-                    let message = format!(
-                        "person id counter returned invalid json: {err} ({body_text})"
-                    );
+                    let message =
+                        format!("person id counter returned invalid json: {err} ({body_text})");
                     worker::console_error!("{message}");
                     PersonError::Message(message)
                 })
                 .map(|resp| resp.id)
         }
 
-        async fn get_record(
-            &self,
-            distinct_id: &str,
-        ) -> Result<Option<PersonRecord>, PersonError> {
+        async fn get_record(&self, distinct_id: &str) -> Result<Option<PersonRecord>, PersonError> {
             let record: Option<PersonRecord> = self
                 .request_json(distinct_id, Method::Get, "/record", None::<&()>)
                 .await?;
             Ok(record)
         }
 
-        async fn put_record(
-            &self,
-            distinct_id: &str,
-            record: PersonRecord,
-        ) -> Result<(), PersonError> {
-            self.request_empty(distinct_id, Method::Post, "/set_record", Some(&record))
-                .await
-        }
-
-        async fn redirect(
-            &self,
-            distinct_id: &str,
-            redirect_to: &str,
-        ) -> Result<(), PersonError> {
+        async fn redirect(&self, distinct_id: &str, redirect_to: &str) -> Result<(), PersonError> {
             self.request_empty(
                 distinct_id,
                 Method::Post,
@@ -729,30 +827,32 @@ mod durable {
     impl PersonStore for DurablePersonStore {
         async fn apply_update(&self, update: PersonUpdate) -> Result<PersonSnapshot, PersonError> {
             let canonical = self.resolve_id(&update.distinct_id).await?;
-            let mut record = self
-                .get_record(&canonical)
-                .await?
-                .unwrap_or_else(|| {
-                    PersonRecord::new(
-                        canonical.clone(),
-                        self.team_id,
-                        0,
-                    )
-                });
-            if record.id == 0 {
-                record.id = self.next_person_id().await?;
-            }
-            record.apply_update(&update);
-            self.put_record(&canonical, record).await?;
+            let original_distinct_id = update.distinct_id.clone();
+            let record: PersonRecord = self
+                .request_json(
+                    &canonical,
+                    Method::Post,
+                    "/apply",
+                    Some(&ApplyPersonUpdateRequest {
+                        update,
+                        team_id: self.team_id,
+                        allocated_id: self.next_person_id().await?,
+                    }),
+                )
+                .await?;
 
-            if canonical != update.distinct_id {
-                self.redirect(&update.distinct_id, &canonical).await?;
+            if canonical != original_distinct_id {
+                self.redirect(&original_distinct_id, &canonical).await?;
+            }
+            for id in &record.distinct_ids {
+                if id != &canonical {
+                    self.redirect(id, &canonical).await?;
+                }
             }
 
-            let record = self.get_record(&canonical).await?;
             Ok(PersonSnapshot {
                 canonical_id: canonical,
-                record,
+                record: Some(record),
             })
         }
 
@@ -768,62 +868,60 @@ mod durable {
                 });
             }
 
-            let mut primary_record = self
-                .get_record(&primary_id)
-                .await?
-                .unwrap_or_else(|| PersonRecord::new(primary_id.clone(), self.team_id, 0));
-            if primary_record.id == 0 {
-                primary_record.id = self.next_person_id().await?;
-            }
-            primary_record.ensure_distinct_id(&alias.distinct_id);
+            let secondary = self.get_record(&secondary_id).await?;
+            let merged: PersonRecord = self
+                .request_json(
+                    &primary_id,
+                    Method::Post,
+                    "/merge",
+                    Some(&MergePersonRequest {
+                        alias: PersonAliasWire {
+                            distinct_id: alias.distinct_id,
+                            alias: alias.alias,
+                        },
+                        secondary,
+                        team_id: self.team_id,
+                        primary_allocated_id: self.next_person_id().await?,
+                        secondary_allocated_id: self.next_person_id().await?,
+                    }),
+                )
+                .await?;
 
-            let mut secondary_record = self
-                .get_record(&secondary_id)
-                .await?
-                .unwrap_or_else(|| PersonRecord::new(secondary_id.clone(), self.team_id, 0));
-            if secondary_record.id == 0 {
-                secondary_record.id = self.next_person_id().await?;
-            }
-            secondary_record.ensure_distinct_id(&alias.alias);
-
-            let merged = PersonRecord::merge(&primary_record, &secondary_record);
-            self.put_record(&primary_id, merged).await?;
-
-            for id in &secondary_record.distinct_ids {
-                self.redirect(id, &primary_id).await?;
+            for id in &merged.distinct_ids {
+                if id != &primary_id {
+                    self.redirect(id, &primary_id).await?;
+                }
             }
             self.redirect(&secondary_id, &primary_id).await?;
-            self.redirect(&alias.alias, &primary_id).await?;
 
-            let record = self.get_record(&primary_id).await?;
             Ok(PersonSnapshot {
                 canonical_id: primary_id,
-                record,
+                record: Some(merged),
             })
         }
 
         async fn ensure_person(&self, distinct_id: &str) -> Result<PersonSnapshot, PersonError> {
             let canonical = self.resolve_id(distinct_id).await?;
-            let mut record = self
-                .get_record(&canonical)
-                .await?
-                .unwrap_or_else(|| PersonRecord::new(canonical.clone(), self.team_id, 0));
-            if record.id == 0 {
-                record.id = self.next_person_id().await?;
-            }
-            if !record.distinct_ids.iter().any(|id| id == distinct_id) {
-                record.ensure_distinct_id(distinct_id);
-                self.put_record(&canonical, record).await?;
-            }
+            let record: PersonRecord = self
+                .request_json(
+                    &canonical,
+                    Method::Post,
+                    "/ensure",
+                    Some(&EnsurePersonRequest {
+                        distinct_id: distinct_id.to_string(),
+                        team_id: self.team_id,
+                        allocated_id: self.next_person_id().await?,
+                    }),
+                )
+                .await?;
 
             if canonical != distinct_id {
                 self.redirect(distinct_id, &canonical).await?;
             }
 
-            let record = self.get_record(&canonical).await?;
             Ok(PersonSnapshot {
                 canonical_id: canonical,
-                record,
+                record: Some(record),
             })
         }
 
@@ -837,10 +935,7 @@ mod durable {
         }
     }
 
-    pub fn store_from_env(
-        env: &Env,
-        team_id: Option<i64>,
-    ) -> std::sync::Arc<dyn PersonStore> {
+    pub fn store_from_env(env: &Env, team_id: Option<i64>) -> std::sync::Arc<dyn PersonStore> {
         match env.durable_object("PERSONS") {
             Ok(namespace) => {
                 let counter = env.durable_object("PERSON_ID_COUNTER").ok();
@@ -930,9 +1025,7 @@ mod tests {
     #[test]
     fn merge_prefers_primary() {
         let mut primary = PersonRecord::new("primary".to_string(), None, 1);
-        primary
-            .properties
-            .insert("plan".to_string(), json!("pro"));
+        primary.properties.insert("plan".to_string(), json!("pro"));
         primary
             .properties_set_once
             .insert("created_at".to_string(), json!("2024-01-01"));
@@ -957,5 +1050,18 @@ mod tests {
         );
         assert!(merged.distinct_ids.contains(&"primary".to_string()));
         assert!(merged.distinct_ids.contains(&"secondary".to_string()));
+    }
+
+    #[tokio::test]
+    async fn memory_redirect_cycles_choose_stable_canonical() {
+        let store = MemoryPersonStore::new(None);
+        {
+            let mut redirects = store.redirects.write().await;
+            redirects.insert("a".to_string(), "b".to_string());
+            redirects.insert("b".to_string(), "a".to_string());
+        }
+
+        assert_eq!(store.resolve_id("a").await, "a");
+        assert_eq!(store.resolve_id("b").await, "a");
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -14,8 +14,8 @@ use reqwest::Client;
 
 #[cfg(target_arch = "wasm32")]
 use worker::{
-    AbortController, Delay, Fetch, Headers, Method, Request, RequestInit,
-    wasm_bindgen::JsValue, wasm_bindgen_futures::spawn_local,
+    wasm_bindgen::JsValue, wasm_bindgen_futures::spawn_local, AbortController, Delay, Fetch,
+    Headers, Method, Request, RequestInit,
 };
 
 use crate::models::{
@@ -103,9 +103,8 @@ impl PipelineClient {
             init.with_headers(headers);
             init.with_body(Some(JsValue::from_str(&body)));
 
-            let request =
-                Request::new_with_init(self.endpoint.as_str(), &init)
-                    .map_err(PipelineError::RequestBuild)?;
+            let request = Request::new_with_init(self.endpoint.as_str(), &init)
+                .map_err(PipelineError::RequestBuild)?;
 
             let controller = AbortController::default();
             let signal = controller.signal();
@@ -431,7 +430,6 @@ impl PipelineEvent {
         self.properties = Some(merged);
         self
     }
-
 }
 
 #[derive(Debug, Error)]
@@ -572,14 +570,8 @@ mod tests {
         };
 
         let mut enrichment = Map::new();
-        enrichment.insert(
-            "$ip".to_string(),
-            Value::String("198.51.100.2".to_string()),
-        );
-        enrichment.insert(
-            "cf_ray".to_string(),
-            Value::String("ray-xyz".to_string()),
-        );
+        enrichment.insert("$ip".to_string(), Value::String("198.51.100.2".to_string()));
+        enrichment.insert("cf_ray".to_string(), Value::String("ray-xyz".to_string()));
 
         let event = PipelineEvent::from_capture(payload).with_enrichment(&enrichment);
         let props = match event.properties {

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -63,6 +63,27 @@ pub async fn spawn_app_with_options(
     signing_secret: Option<String>,
     feature_flags: Option<hogflare::feature_flags::FeatureFlagStore>,
 ) -> Result<(SocketAddr, JoinHandle<()>), Box<dyn std::error::Error>> {
+    spawn_app_with_runtime_options(
+        pipeline_endpoint,
+        decide_api_token,
+        session_recording_endpoint,
+        signing_secret,
+        None,
+        feature_flags,
+        hogflare::groups::GroupTypeMap::default(),
+    )
+    .await
+}
+
+pub async fn spawn_app_with_runtime_options(
+    pipeline_endpoint: Url,
+    decide_api_token: Option<String>,
+    session_recording_endpoint: Option<String>,
+    signing_secret: Option<String>,
+    person_debug_token: Option<String>,
+    feature_flags: Option<hogflare::feature_flags::FeatureFlagStore>,
+    group_type_map: hogflare::groups::GroupTypeMap,
+) -> Result<(SocketAddr, JoinHandle<()>), Box<dyn std::error::Error>> {
     let pipeline_client = PipelineClient::new(pipeline_endpoint, None, Duration::from_secs(5))?;
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -75,13 +96,15 @@ pub async fn spawn_app_with_options(
                 listener,
                 pipeline,
                 None,
-                Arc::new(hogflare::groups::NoopGroupStore),
-                hogflare::groups::GroupTypeMap::default(),
+                Arc::new(hogflare::groups::MemoryGroupStore::new()),
+                group_type_map,
                 decide_api_token,
                 session_recording_endpoint,
                 signing_secret,
-                None,
-                Arc::new(feature_flags.unwrap_or_else(hogflare::feature_flags::FeatureFlagStore::empty)),
+                person_debug_token,
+                Arc::new(
+                    feature_flags.unwrap_or_else(hogflare::feature_flags::FeatureFlagStore::empty),
+                ),
             )
             .await
             {
@@ -101,6 +124,38 @@ pub async fn wait_for_events(
         Ok(None) => Err("pipeline receiver closed unexpectedly".into()),
         Err(_) => Err("timed out waiting for pipeline payload".into()),
     }
+}
+
+pub async fn collect_events_until(
+    receiver: &mut mpsc::Receiver<Vec<Value>>,
+    min_count: usize,
+    deadline_after: Duration,
+) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let deadline = tokio::time::Instant::now() + deadline_after;
+    let mut all_events = Vec::new();
+
+    while all_events.len() < min_count && tokio::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+
+        match timeout(remaining.min(Duration::from_millis(500)), receiver.recv()).await {
+            Ok(Some(events)) => all_events.extend(events),
+            Ok(None) => return Err("pipeline receiver closed unexpectedly".into()),
+            Err(_) => {}
+        }
+    }
+
+    if all_events.len() < min_count {
+        return Err(format!(
+            "timed out waiting for {min_count} events, received {}",
+            all_events.len()
+        )
+        .into());
+    }
+
+    Ok(all_events)
 }
 
 pub async fn cleanup(server_handle: JoinHandle<()>, pipeline_handle: JoinHandle<()>) {

--- a/tests/js_client/bun.lock
+++ b/tests/js_client/bun.lock
@@ -1,12 +1,13 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "hogflare-integration-tests",
       "dependencies": {
         "jsdom": "^24.0.0",
-        "posthog-js": "^1.200.0",
-        "posthog-node": "^5.17.4",
+        "posthog-js": "^1.373.4",
+        "posthog-node": "^5.34.1",
       },
     },
   },
@@ -23,7 +24,55 @@
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
 
-    "@posthog/core": ["@posthog/core@1.2.2", "", {}, "sha512-f16Ozx6LIigRG+HsJdt+7kgSxZTHeX5f1JlCGKI1lXcvlZgfsCR338FuMI2QRYXGl+jg/vYFzGOTQBxl90lnBg=="],
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.208.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
+
+    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/sdk-logs": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.208.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.208.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
+    "@posthog/core": ["@posthog/core@1.29.1", "", { "dependencies": { "@posthog/types": "1.373.4" } }, "sha512-q+/t/DZALr50YTE0dFgfGSS9EgwcyAlqsn+JS61wLkwdcDM5yu/YTDM8oMKmJupsyjSZlVkDuHZAMd4ab7AxzQ=="],
+
+    "@posthog/types": ["@posthog/types@1.373.4", "", {}, "sha512-n+0AbGRYYsbi+CQXQi2rF1lwTSyASlaogcw4YSkzB5KeMa4Y6nhNb7+TTnu9aVor+BycsQYCa2OsBrMMbaTekw=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.1", "", {}, "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
+
+    "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -35,8 +84,6 @@
 
     "core-js": ["core-js@3.45.1", "", {}, "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg=="],
 
-    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
-
     "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
 
     "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
@@ -46,6 +93,8 @@
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dompurify": ["dompurify@3.4.2", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -87,9 +136,9 @@
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
-    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
     "jsdom": ["jsdom@24.1.3", "", { "dependencies": { "cssstyle": "^4.0.1", "data-urls": "^5.0.0", "decimal.js": "^10.4.3", "form-data": "^4.0.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.5", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.12", "parse5": "^7.1.2", "rrweb-cssom": "^0.7.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^4.1.4", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^2.11.2" }, "optionalPeers": ["canvas"] }, "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -105,17 +154,19 @@
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
-    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+    "posthog-js": ["posthog-js@1.373.4", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.208.0", "@opentelemetry/exporter-logs-otlp-http": "^0.208.0", "@opentelemetry/resources": "^2.2.0", "@opentelemetry/sdk-logs": "^0.208.0", "@posthog/core": "1.29.1", "@posthog/types": "1.373.4", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-6DueUS5KOGZlKsQlelLURmtp9PA52rdCxt/IvuoYKAErlkh2LczogMopUIpeqbwfOnGDQEf8gmDh4z/IFeU4CQ=="],
 
-    "posthog-js": ["posthog-js@1.273.1", "", { "dependencies": { "@posthog/core": "1.2.2", "core-js": "^3.38.1", "fflate": "^0.4.8", "preact": "^10.19.3", "web-vitals": "^4.2.4" }, "peerDependencies": { "@rrweb/types": "2.0.0-alpha.17", "rrweb-snapshot": "2.0.0-alpha.17" }, "optionalPeers": ["@rrweb/types", "rrweb-snapshot"] }, "sha512-6w3j6nAWJj7W7/iksWLXRpdLrLZrQA8jTsEQ71bvmyw4bwCqhgPfxutrmeoAUNaxot2FB1JHc9Lagslg35h61g=="],
+    "posthog-node": ["posthog-node@5.34.1", "", { "dependencies": { "@posthog/core": "1.29.1" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-kGl0kSfh2+Ey3KL5Sji3yv9W5xwPK9sTkINRoFqCh9fbYXWWY6Zwi5Psv2QmRcbYiMJBk/iecnoOKVDRRga6PA=="],
 
-    "posthog-node": ["posthog-node@5.17.4", "", { "dependencies": { "@posthog/core": "1.8.1" } }, "sha512-hrd+Do/DMt40By12ESIDUfD81V9OASjq9XHjycZrGiD8cX/ZwCIVSJLUb7nQmvSCWcKII+u+nnPVuc4LjTDl9g=="],
+    "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
 
-    "preact": ["preact@10.27.2", "", {}, "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg=="],
+    "protobufjs": ["protobufjs@7.5.8", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.1", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA=="],
 
     "psl": ["psl@1.15.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "querystringify": ["querystringify@2.2.0", "", {}, "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="],
 
@@ -127,15 +178,13 @@
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
-    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
-
-    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
-
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
 
     "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
+    "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
 
     "universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
 
@@ -143,7 +192,7 @@
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
-    "web-vitals": ["web-vitals@4.2.4", "", {}, "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw=="],
+    "web-vitals": ["web-vitals@5.2.0", "", {}, "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
@@ -153,16 +202,22 @@
 
     "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
-    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
-
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
-    "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+    "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 
-    "posthog-node/@posthog/core": ["@posthog/core@1.8.1", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-jfzBtQIk9auRi/biO+G/gumK5KxqsD5wOr7XpYMROE/I3pazjP4zIziinp21iQuIQJMXrDvwt9Af3njgOGwtew=="],
+    "@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
+
+    "@opentelemetry/sdk-metrics/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
+
+    "@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
+
+    "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
   }
 }

--- a/tests/js_client/bun.lock
+++ b/tests/js_client/bun.lock
@@ -9,10 +9,29 @@
         "posthog-js": "^1.373.4",
         "posthog-node": "^5.34.1",
       },
+      "devDependencies": {
+        "wrangler": "4.90.1",
+      },
     },
   },
   "packages": {
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260508.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-IT3r6VgiSwIesL4AJbxjgxvIxwWZqM7BKkhYAzOKHl4GF2M0TxeOahUIXd+CYXVZgHX8ceEg+MXbEehPelJyNg=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260508.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JTVsisOJPcNKw0qovPjqyBWYahfdhUh7/9NICiG5wxaEQ45PYKdoqNq0hOAAIqvqoxsKZBvTgcPTJREPqk7avA=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260508.1", "", { "os": "linux", "cpu": "x64" }, "sha512-zO38pCc27YlsZiPYcaZnosy0/t7abXrRU3VEO1oKfUvnaCpHgphDG+VsrmHL+kntda6hrtNwg2jLeMAqqIjnjw=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260508.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-XhJa780Ia6MNIrtxn/ruZHS79b9pu5EKPfRNReaUqxy8erPT2fs93axMfFoS9kIkcaRRj/1TOUKcTeAMoywY7w=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260508.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QdDOK3B/Ul1s3QmIwDrFyx9230to6LsNmWcVR8w+TYjNZuRPzqQBgusp78LO7MlqCoEl9dvIcN00jkJnLtBSfw=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
@@ -23,6 +42,116 @@
     "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
@@ -45,6 +174,12 @@
     "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
     "@posthog/core": ["@posthog/core@1.29.1", "", { "dependencies": { "@posthog/types": "1.373.4" } }, "sha512-q+/t/DZALr50YTE0dFgfGSS9EgwcyAlqsn+JS61wLkwdcDM5yu/YTDM8oMKmJupsyjSZlVkDuHZAMd4ab7AxzQ=="],
 
@@ -70,6 +205,10 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
+
     "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
@@ -78,9 +217,13 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "core-js": ["core-js@3.45.1", "", {}, "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg=="],
 
@@ -94,11 +237,15 @@
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "dompurify": ["dompurify@3.4.2", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -108,9 +255,13 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
+    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
     "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "form-data": ["form-data@4.0.4", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -138,6 +289,8 @@
 
     "jsdom": ["jsdom@24.1.3", "", { "dependencies": { "cssstyle": "^4.0.1", "data-urls": "^5.0.0", "decimal.js": "^10.4.3", "form-data": "^4.0.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.5", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.12", "parse5": "^7.1.2", "rrweb-cssom": "^0.7.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^4.1.4", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^2.11.2" }, "optionalPeers": ["canvas"] }, "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ=="],
 
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -148,11 +301,17 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "miniflare": ["miniflare@4.20260508.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260508.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-h3aG+PA8jEH76V4ZtBAbs3g7kjMfHJUF8hPvxeeajLTKwir+G+dqfBODg5yF9MT29LqrZKCRQRqzfHPWX4kCIg=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nwsapi": ["nwsapi@2.2.22", "", {}, "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "posthog-js": ["posthog-js@1.373.4", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.208.0", "@opentelemetry/exporter-logs-otlp-http": "^0.208.0", "@opentelemetry/resources": "^2.2.0", "@opentelemetry/sdk-logs": "^0.208.0", "@posthog/core": "1.29.1", "@posthog/types": "1.373.4", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-6DueUS5KOGZlKsQlelLURmtp9PA52rdCxt/IvuoYKAErlkh2LczogMopUIpeqbwfOnGDQEf8gmDh4z/IFeU4CQ=="],
 
@@ -178,13 +337,25 @@
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
+    "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
 
     "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
+
     "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
 
@@ -202,11 +373,19 @@
 
     "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
+    "workerd": ["workerd@1.20260508.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260508.1", "@cloudflare/workerd-darwin-arm64": "1.20260508.1", "@cloudflare/workerd-linux-64": "1.20260508.1", "@cloudflare/workerd-linux-arm64": "1.20260508.1", "@cloudflare/workerd-windows-64": "1.20260508.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-VlnjyH3AjVddpSK7J54nsCVgf8i2733pl8GjKttfNi7vN/hEjjAk20d2b1nDToOLKvRQpTewRnVkqaaeGHCaAw=="],
+
+    "wrangler": ["wrangler@4.90.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260508.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260508.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260508.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-u2KrieKSMfRM0toTst/CfDtcRraeoVjmcExcMWgILM/ytq3qcDhuOAULoZSyPHzma43lfLJy1BC544drFyqe1A=="],
+
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
     "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 
@@ -219,5 +398,7 @@
     "@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 
     "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
   }
 }

--- a/tests/js_client/package.json
+++ b/tests/js_client/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "jsdom": "^24.0.0",
-    "posthog-js": "^1.200.0",
-    "posthog-node": "^5.17.4"
+    "posthog-js": "^1.373.4",
+    "posthog-node": "^5.34.1"
   }
 }

--- a/tests/js_client/package.json
+++ b/tests/js_client/package.json
@@ -8,5 +8,8 @@
     "jsdom": "^24.0.0",
     "posthog-js": "^1.373.4",
     "posthog-node": "^5.34.1"
+  },
+  "devDependencies": {
+    "wrangler": "4.90.1"
   }
 }

--- a/tests/js_client/posthog_compressed_group_flow.js
+++ b/tests/js_client/posthog_compressed_group_flow.js
@@ -1,0 +1,28 @@
+import { setupPosthog, waitForFlush } from './setup.js';
+
+async function main() {
+  const { posthog } = await setupPosthog({
+    disable_compression: false,
+    request_batching: false,
+  });
+
+  posthog.group('company', 'sdk-acme', {
+    plan: 'enterprise',
+    seats: 42,
+  });
+
+  await waitForFlush(750);
+
+  posthog.capture('js-grouped-capture', {
+    client: 'posthog-js',
+    action: 'grouped',
+  });
+
+  await waitForFlush(1500);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/js_client/posthog_identify_alias.js
+++ b/tests/js_client/posthog_identify_alias.js
@@ -1,0 +1,29 @@
+import { setupPosthog, waitForFlush } from './setup.js';
+
+async function main() {
+  const anonId = process.env.HOGFLARE_ANON_DISTINCT_ID || 'anonymous-sdk-user';
+  const identifiedId = process.env.HOGFLARE_IDENTIFIED_ID || 'identified-sdk-user';
+
+  const { posthog } = await setupPosthog({
+    disable_compression: false,
+    request_batching: false,
+    disable_persistence: false,
+    bootstrap: {
+      distinctID: anonId,
+      isIdentifiedID: false,
+    },
+  });
+
+  posthog.identify(identifiedId, {
+    email: 'sdk-identify@example.com',
+    plan: 'enterprise',
+  });
+
+  await waitForFlush(1500);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/js_client/posthog_node_group_flow.js
+++ b/tests/js_client/posthog_node_group_flow.js
@@ -1,0 +1,38 @@
+import { PostHog } from 'posthog-node';
+
+async function main() {
+  const apiHost = process.env.HOGFLARE_HOST;
+  if (!apiHost) {
+    throw new Error('HOGFLARE_HOST must be provided');
+  }
+
+  const apiKey = process.env.HOGFLARE_API_KEY || 'phc_test_node_key';
+  const distinctId = process.env.HOGFLARE_DISTINCT_ID || 'node-group-user';
+  const client = new PostHog(apiKey, { host: apiHost });
+
+  client.groupIdentify({
+    groupType: 'company',
+    groupKey: 'node-acme',
+    distinctId,
+    properties: {
+      plan: 'enterprise',
+      seats: 12,
+    },
+  });
+
+  client.capture({
+    distinctId,
+    event: 'node-grouped-capture',
+    groups: { company: 'node-acme' },
+    properties: {
+      client: 'posthog-node',
+    },
+  });
+
+  await client.shutdown();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/js_client/posthog_node_official_flags.js
+++ b/tests/js_client/posthog_node_official_flags.js
@@ -1,0 +1,39 @@
+import { PostHog } from 'posthog-node';
+
+async function main() {
+  const apiHost = process.env.HOGFLARE_HOST;
+  if (!apiHost) {
+    throw new Error('HOGFLARE_HOST must be provided');
+  }
+
+  const apiKey = process.env.HOGFLARE_API_KEY || 'phc_test_node_key';
+  const distinctId = process.env.HOGFLARE_DISTINCT_ID || 'node-official-flag-user';
+  const groupKey = process.env.HOGFLARE_GROUP_KEY || 'node-flags-company';
+
+  const ingestClient = new PostHog(apiKey, { host: apiHost });
+  ingestClient.groupIdentify({
+    groupType: 'company',
+    groupKey,
+    distinctId,
+    properties: {
+      plan: 'enterprise',
+    },
+  });
+  await ingestClient.shutdown();
+
+  const flagClient = new PostHog(apiKey, { host: apiHost });
+  const groups = { company: groupKey };
+  const distinct = await flagClient.getFeatureFlag('sdk-distinct-flag', distinctId);
+  const groupKeyFlag = await flagClient.getFeatureFlag('sdk-group-key-flag', distinctId, { groups });
+  const groupPlan = await flagClient.getFeatureFlag('sdk-group-plan-flag', distinctId, { groups });
+  const variant = await flagClient.getFeatureFlag('sdk-variant-flag', distinctId);
+  const payload = await flagClient.getFeatureFlagPayload('sdk-variant-flag', distinctId, variant);
+  await flagClient.shutdown();
+
+  console.log(JSON.stringify({ distinct, groupKeyFlag, groupPlan, variant, payload }));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/persons_do.rs
+++ b/tests/persons_do.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use std::fs;
 use std::net::TcpListener;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 use tempfile::TempDir;
@@ -17,6 +17,20 @@ use tokio::process::{Child, Command};
 struct PersonDebugResponse {
     canonical_id: String,
     record: Option<Value>,
+}
+
+struct WranglerDev {
+    child: Child,
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+}
+
+impl WranglerDev {
+    fn logs(&self) -> String {
+        let stdout = read_log(&self.stdout_path);
+        let stderr = read_log(&self.stderr_path);
+        format!("wrangler stdout:\n{stdout}\nwrangler stderr:\n{stderr}")
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -31,7 +45,7 @@ async fn durable_object_person_updates_apply() -> Result<(), Box<dyn std::error:
         write_wrangler_config(temp_dir.path(), &pipeline_endpoint.to_string(), debug_token)?;
     patch_worker_bundle()?;
 
-    let mut wrangler = spawn_wrangler_dev(&config_path, port)?;
+    let mut wrangler = spawn_wrangler_dev(&config_path, port, temp_dir.path())?;
     wait_for_health(port, &mut wrangler).await?;
 
     let client = Client::builder().timeout(Duration::from_secs(5)).build()?;
@@ -102,7 +116,7 @@ fn reserve_port() -> Result<u16, Box<dyn std::error::Error>> {
 }
 
 fn write_wrangler_config(
-    dir: &std::path::Path,
+    dir: &Path,
     pipeline_endpoint: &str,
     debug_token: &str,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
@@ -169,7 +183,13 @@ export * from "./index.mjs";
 fn spawn_wrangler_dev(
     config_path: &PathBuf,
     port: u16,
-) -> Result<Child, Box<dyn std::error::Error>> {
+    log_dir: &Path,
+) -> Result<WranglerDev, Box<dyn std::error::Error>> {
+    let stdout_path = log_dir.join("wrangler.stdout.log");
+    let stderr_path = log_dir.join("wrangler.stderr.log");
+    let stdout = fs::File::create(&stdout_path)?;
+    let stderr = fs::File::create(&stderr_path)?;
+
     let child = Command::new("bunx")
         .arg("wrangler")
         .arg("dev")
@@ -183,16 +203,20 @@ fn spawn_wrangler_dev(
         .arg("--log-level")
         .arg("error")
         .env("WRANGLER_SEND_METRICS", "false")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
         .spawn()?;
 
-    Ok(child)
+    Ok(WranglerDev {
+        child,
+        stdout_path,
+        stderr_path,
+    })
 }
 
 async fn wait_for_health(
     port: u16,
-    wrangler: &mut Child,
+    wrangler: &mut WranglerDev,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::builder().timeout(Duration::from_secs(2)).build()?;
     let url = format!("http://127.0.0.1:{port}/healthz");
@@ -200,10 +224,12 @@ async fn wait_for_health(
     let mut last_failure = String::from("no response yet");
 
     while tokio::time::Instant::now() < deadline {
-        if let Some(status) = wrangler.try_wait()? {
-            return Err(
-                format!("wrangler dev exited before health check succeeded: {status}").into(),
-            );
+        if let Some(status) = wrangler.child.try_wait()? {
+            return Err(format!(
+                "wrangler dev exited before health check succeeded: {status}\n{}",
+                wrangler.logs()
+            )
+            .into());
         }
 
         match client.get(&url).send().await {
@@ -221,11 +247,27 @@ async fn wait_for_health(
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
 
-    if let Some(status) = wrangler.try_wait()? {
-        return Err(format!("wrangler dev exited before health check succeeded: {status}").into());
+    if let Some(status) = wrangler.child.try_wait()? {
+        return Err(format!(
+            "wrangler dev exited before health check succeeded: {status}\n{}",
+            wrangler.logs()
+        )
+        .into());
     }
 
-    Err(format!("timed out after 90s waiting for wrangler dev at {url}: {last_failure}").into())
+    Err(format!(
+        "timed out after 90s waiting for wrangler dev at {url}: {last_failure}\n{}",
+        wrangler.logs()
+    )
+    .into())
+}
+
+fn read_log(path: &Path) -> String {
+    match fs::read_to_string(path) {
+        Ok(contents) if contents.trim().is_empty() => "<empty>".to_string(),
+        Ok(contents) => contents,
+        Err(err) => format!("<failed to read {}: {err}>", path.display()),
+    }
 }
 
 async fn fetch_person(
@@ -253,10 +295,10 @@ async fn cleanup_pipeline(pipeline_handle: tokio::task::JoinHandle<()>) {
     let _ = pipeline_handle.await;
 }
 
-async fn shutdown_wrangler(child: &mut Child) {
-    let _ = child.kill().await;
+async fn shutdown_wrangler(wrangler: &mut WranglerDev) {
+    let _ = wrangler.child.kill().await;
 }
 
-async fn cleanup_wrangler(child: &mut Child) {
-    let _ = child.wait().await;
+async fn cleanup_wrangler(wrangler: &mut WranglerDev) {
+    let _ = wrangler.child.wait().await;
 }

--- a/tests/persons_do.rs
+++ b/tests/persons_do.rs
@@ -32,7 +32,7 @@ async fn durable_object_person_updates_apply() -> Result<(), Box<dyn std::error:
     patch_worker_bundle()?;
 
     let mut wrangler = spawn_wrangler_dev(&config_path, port)?;
-    wait_for_health(port).await?;
+    wait_for_health(port, &mut wrangler).await?;
 
     let client = Client::builder().timeout(Duration::from_secs(5)).build()?;
     let base_url = format!("http://127.0.0.1:{port}");
@@ -190,20 +190,42 @@ fn spawn_wrangler_dev(
     Ok(child)
 }
 
-async fn wait_for_health(port: u16) -> Result<(), Box<dyn std::error::Error>> {
-    let client = Client::builder().timeout(Duration::from_secs(1)).build()?;
+async fn wait_for_health(
+    port: u16,
+    wrangler: &mut Child,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::builder().timeout(Duration::from_secs(2)).build()?;
     let url = format!("http://127.0.0.1:{port}/healthz");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(90);
+    let mut last_failure = String::from("no response yet");
 
-    for _ in 0..60 {
-        if let Ok(resp) = client.get(&url).send().await {
-            if resp.status().is_success() {
-                return Ok(());
+    while tokio::time::Instant::now() < deadline {
+        if let Some(status) = wrangler.try_wait()? {
+            return Err(
+                format!("wrangler dev exited before health check succeeded: {status}").into(),
+            );
+        }
+
+        match client.get(&url).send().await {
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    return Ok(());
+                }
+                last_failure = format!("last status {}", resp.status());
+            }
+            Err(err) => {
+                last_failure = err.to_string();
             }
         }
-        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
     }
 
-    Err("timed out waiting for wrangler dev".into())
+    if let Some(status) = wrangler.try_wait()? {
+        return Err(format!("wrangler dev exited before health check succeeded: {status}").into());
+    }
+
+    Err(format!("timed out after 90s waiting for wrangler dev at {url}: {last_failure}").into())
 }
 
 async fn fetch_person(

--- a/tests/persons_do.rs
+++ b/tests/persons_do.rs
@@ -132,9 +132,6 @@ CLOUDFLARE_PIPELINE_ENDPOINT = "{pipeline}"
 CLOUDFLARE_PIPELINE_TIMEOUT_SECS = "5"
 PERSON_DEBUG_TOKEN = "{debug_token}"
 
-[build.upload]
-format = "modules"
-
 [[durable_objects.bindings]]
 name = "PERSONS"
 class_name = "PersonDurableObject"
@@ -189,9 +186,10 @@ fn spawn_wrangler_dev(
     let stderr_path = log_dir.join("wrangler.stderr.log");
     let stdout = fs::File::create(&stdout_path)?;
     let stderr = fs::File::create(&stderr_path)?;
+    let wrangler_script = wrangler_script_path()?;
 
-    let child = Command::new("bunx")
-        .arg("wrangler")
+    let child = Command::new("node")
+        .arg(wrangler_script)
         .arg("dev")
         .arg("--local")
         .arg("--config")
@@ -212,6 +210,19 @@ fn spawn_wrangler_dev(
         stdout_path,
         stderr_path,
     })
+}
+
+fn wrangler_script_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let path =
+        std::env::current_dir()?.join("tests/js_client/node_modules/wrangler/bin/wrangler.js");
+    if !path.exists() {
+        return Err(format!(
+            "missing Wrangler CLI at {}; run `bun install --cwd tests/js_client`",
+            path.display()
+        )
+        .into());
+    }
+    Ok(path)
 }
 
 async fn wait_for_health(

--- a/tests/persons_do.rs
+++ b/tests/persons_do.rs
@@ -27,11 +27,8 @@ async fn durable_object_person_updates_apply() -> Result<(), Box<dyn std::error:
     let temp_dir = TempDir::new()?;
     let debug_token = "debug-test-token";
 
-    let config_path = write_wrangler_config(
-        temp_dir.path(),
-        &pipeline_endpoint.to_string(),
-        debug_token,
-    )?;
+    let config_path =
+        write_wrangler_config(temp_dir.path(), &pipeline_endpoint.to_string(), debug_token)?;
     patch_worker_bundle()?;
 
     let mut wrangler = spawn_wrangler_dev(&config_path, port)?;
@@ -134,7 +131,7 @@ class_name = "PersonIdCounterDurableObject"
 
 [[migrations]]
 tag = "v1"
-new_classes = ["PersonDurableObject", "PersonIdCounterDurableObject"]
+new_sqlite_classes = ["PersonDurableObject", "PersonIdCounterDurableObject"]
 "#,
         main = main_path.display(),
         pipeline = pipeline_endpoint,
@@ -154,11 +151,7 @@ fn patch_worker_bundle() -> Result<(), Box<dyn std::error::Error>> {
     }
     let contents = fs::read_to_string(&bundle_path)?;
     let patched = if contents.starts_with("import source wasmModule") {
-        contents.replacen(
-            "import source wasmModule from",
-            "import wasmModule from",
-            1,
-        )
+        contents.replacen("import source wasmModule from", "import wasmModule from", 1)
     } else {
         contents
     };
@@ -173,7 +166,10 @@ export * from "./index.mjs";
     Ok(())
 }
 
-fn spawn_wrangler_dev(config_path: &PathBuf, port: u16) -> Result<Child, Box<dyn std::error::Error>> {
+fn spawn_wrangler_dev(
+    config_path: &PathBuf,
+    port: u16,
+) -> Result<Child, Box<dyn std::error::Error>> {
     let child = Command::new("bunx")
         .arg("wrangler")
         .arg("dev")
@@ -230,9 +226,7 @@ async fn fetch_person(
     Ok(payload)
 }
 
-async fn cleanup_pipeline(
-    pipeline_handle: tokio::task::JoinHandle<()>,
-) {
+async fn cleanup_pipeline(pipeline_handle: tokio::task::JoinHandle<()>) {
     pipeline_handle.abort();
     let _ = pipeline_handle.await;
 }

--- a/tests/pipeline_e2e.rs
+++ b/tests/pipeline_e2e.rs
@@ -135,7 +135,7 @@ async fn pipeline_handles_capture_batch_alias_and_session() -> Result<(), Box<dy
             events
                 .iter()
                 .find(|event| {
-                event["event"] == event_type
+                    event["event"] == event_type
                         && distinct_id.map_or(true, |id| event["distinct_id"] == id)
                 })
                 .unwrap_or_else(|| {

--- a/tests/posthog_endpoints.rs
+++ b/tests/posthog_endpoints.rs
@@ -1,13 +1,24 @@
 #[path = "helpers/mod.rs"]
 mod helpers;
 
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
 use chrono::Utc;
-use helpers::{cleanup, spawn_app_with_options, spawn_pipeline_stub, wait_for_events};
+use helpers::{
+    cleanup, spawn_app_with_options, spawn_app_with_runtime_options, spawn_pipeline_stub,
+    wait_for_events,
+};
 use hmac::{Hmac, Mac};
+use hogflare::{feature_flags::FeatureFlagStore, groups::GroupTypeMap};
 use reqwest::{Client, StatusCode};
 use serde_json::{json, Value};
 use sha2::Sha256;
 use std::time::Duration;
+
+fn posthog_sha256_signature(secret: &str, body: &str) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+    mac.update(body.as_bytes());
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn capture_requires_signature_when_secret_configured(
@@ -39,15 +50,14 @@ async fn capture_requires_signature_when_secret_configured(
         .await?;
     assert_eq!(unsigned.status(), StatusCode::UNAUTHORIZED);
 
-    let mut mac = Hmac::<Sha256>::new_from_slice(signing_secret.as_bytes()).unwrap();
-    mac.update(body.as_bytes());
-    let signature = hex::encode(mac.finalize().into_bytes());
-
     let signed = client
         .post(format!("{}/capture", base_url))
         .header("Content-Type", "application/json")
         .header("X-POSTHOG-API-KEY", "phc_signature")
-        .header("X-POSTHOG-SIGNATURE", format!("sha256={}", signature))
+        .header(
+            "X-POSTHOG-SIGNATURE",
+            posthog_sha256_signature(signing_secret, &body),
+        )
         .body(body)
         .send()
         .await?;
@@ -57,6 +67,364 @@ async fn capture_requires_signature_when_secret_configured(
     assert_eq!(events.len(), 1);
     assert_eq!(events[0]["event"], "signed-event");
     assert_eq!(events[0]["api_key"], "phc_signature");
+
+    cleanup(server_handle, pipeline_handle).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn browser_endpoint_uses_shared_signed_payload_handling(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let signing_secret = "browser-signing-secret";
+    let (pipeline_endpoint, mut pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
+    let (address, server_handle) = spawn_app_with_options(
+        pipeline_endpoint,
+        None,
+        None,
+        Some(signing_secret.to_string()),
+        None,
+    )
+    .await?;
+
+    let base_url = format!("http://{}", address);
+    let client = Client::builder().timeout(Duration::from_secs(5)).build()?;
+    let embedded = json!({
+        "event": "browser-data-envelope",
+        "properties": {
+            "$distinct_id": "browser-data-user",
+            "source": "data-envelope"
+        }
+    });
+    let body = json!({
+        "api_key": "phc_browser_data",
+        "data": BASE64_STANDARD.encode(embedded.to_string())
+    })
+    .to_string();
+
+    let unsigned = client
+        .post(format!("{}/e", base_url))
+        .header("Content-Type", "application/json")
+        .body(body.clone())
+        .send()
+        .await?;
+    assert_eq!(unsigned.status(), StatusCode::UNAUTHORIZED);
+
+    let signed = client
+        .post(format!("{}/e", base_url))
+        .header("Content-Type", "application/json")
+        .header(
+            "X-POSTHOG-SIGNATURE",
+            posthog_sha256_signature(signing_secret, &body),
+        )
+        .body(body)
+        .send()
+        .await?;
+    assert!(signed.status().is_success());
+
+    let events = wait_for_events(&mut pipeline_rx).await?;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["event"], "browser-data-envelope");
+    assert_eq!(events[0]["distinct_id"], "browser-data-user");
+    assert_eq!(events[0]["api_key"], "phc_browser_data");
+    assert_eq!(events[0]["properties"]["source"], "data-envelope");
+
+    cleanup(server_handle, pipeline_handle).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn browser_identify_links_anon_distinct_id() -> Result<(), Box<dyn std::error::Error>> {
+    let debug_token = "debug-browser-identify";
+    let (pipeline_endpoint, mut pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
+    let (address, server_handle) = spawn_app_with_runtime_options(
+        pipeline_endpoint,
+        None,
+        None,
+        None,
+        Some(debug_token.to_string()),
+        None,
+        GroupTypeMap::default(),
+    )
+    .await?;
+
+    let base_url = format!("http://{}", address);
+    let client = Client::builder().timeout(Duration::from_secs(5)).build()?;
+    let response = client
+        .post(format!("{}/e", base_url))
+        .json(&json!({
+            "token": "phc_browser_identify",
+            "event": "$identify",
+            "distinct_id": "identified-browser-user",
+            "properties": {
+                "$anon_distinct_id": "anonymous-browser-user",
+                "$set": { "email": "browser@example.com" }
+            }
+        }))
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+
+    let events = wait_for_events(&mut pipeline_rx).await?;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["event"], "$identify");
+    assert_eq!(events[0]["distinct_id"], "identified-browser-user");
+    assert_eq!(
+        events[0]["person_properties"]["email"],
+        "browser@example.com"
+    );
+
+    let snapshot: Value = client
+        .get(format!(
+            "{}/__debug/person/{}",
+            base_url, "anonymous-browser-user"
+        ))
+        .header("x-hogflare-debug-token", debug_token)
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(snapshot["canonical_id"], "identified-browser-user");
+    assert_eq!(
+        snapshot["record"]["properties"]["email"],
+        "browser@example.com"
+    );
+
+    cleanup(server_handle, pipeline_handle).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn groupidentify_shapes_create_and_hydrate_groups() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (pipeline_endpoint, mut pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
+    let group_type_map = GroupTypeMap::new([Some("team".to_string()), None, None, None, None]);
+    let (address, server_handle) = spawn_app_with_runtime_options(
+        pipeline_endpoint,
+        None,
+        None,
+        None,
+        None,
+        None,
+        group_type_map,
+    )
+    .await?;
+
+    let base_url = format!("http://{}", address);
+    let client = Client::builder().timeout(Duration::from_secs(5)).build()?;
+
+    let groups_response = client
+        .post(format!("{}/groups", base_url))
+        .json(&json!({
+            "api_key": "phc_groups",
+            "event": "$groupidentify",
+            "distinct_id": "groups-setup",
+            "properties": {
+                "$group_type": "team",
+                "$group_key": "team-42",
+                "$group_set": { "members": 5 }
+            }
+        }))
+        .send()
+        .await?;
+    assert!(groups_response.status().is_success());
+
+    let group_events = wait_for_events(&mut pipeline_rx).await?;
+    assert_eq!(group_events.len(), 1);
+    assert_eq!(group_events[0]["event"], "$groupidentify");
+    assert_eq!(group_events[0]["group0"], "team-42");
+    assert_eq!(group_events[0]["group_properties"]["team"]["members"], 5);
+
+    let capture_response = client
+        .post(format!("{}/capture", base_url))
+        .json(&json!({
+            "api_key": "phc_group_capture",
+            "event": "uses-created-group",
+            "distinct_id": "grouped-user",
+            "properties": {
+                "$groups": { "team": "team-42" }
+            }
+        }))
+        .send()
+        .await?;
+    assert!(capture_response.status().is_success());
+
+    let capture_events = wait_for_events(&mut pipeline_rx).await?;
+    assert_eq!(capture_events.len(), 1);
+    assert_eq!(capture_events[0]["event"], "uses-created-group");
+    assert_eq!(capture_events[0]["group0"], "team-42");
+    assert_eq!(capture_events[0]["group_properties"]["team"]["members"], 5);
+
+    let capture_group_response = client
+        .post(format!("{}/capture", base_url))
+        .json(&json!({
+            "api_key": "phc_capture_groupidentify",
+            "event": "$groupidentify",
+            "distinct_id": "groups-setup",
+            "properties": {
+                "$group_type": "team",
+                "$group_key": "team-43",
+                "$group_set": { "members": 7 }
+            }
+        }))
+        .send()
+        .await?;
+    assert!(capture_group_response.status().is_success());
+
+    let capture_group_events = wait_for_events(&mut pipeline_rx).await?;
+    assert_eq!(capture_group_events.len(), 1);
+    assert_eq!(capture_group_events[0]["event"], "$groupidentify");
+    assert_eq!(capture_group_events[0]["group0"], "team-43");
+    assert_eq!(
+        capture_group_events[0]["group_properties"]["team"]["members"],
+        7
+    );
+
+    let batch_response = client
+        .post(format!("{}/batch", base_url))
+        .json(&json!({
+            "api_key": "phc_batch_groups",
+            "batch": [
+                {
+                    "event": "batch-distinct-in-properties",
+                    "properties": {
+                        "distinct_id": "batch-properties-user",
+                        "$groups": { "team": "team-43" }
+                    }
+                },
+                {
+                    "event": "$groupidentify",
+                    "distinct_id": "groups-setup",
+                    "properties": {
+                        "$group_type": "team",
+                        "$group_key": "team-44",
+                        "$group_set": { "members": 9 }
+                    }
+                }
+            ]
+        }))
+        .send()
+        .await?;
+    assert!(batch_response.status().is_success());
+
+    let batch_events = wait_for_events(&mut pipeline_rx).await?;
+    assert_eq!(batch_events.len(), 2);
+    assert_eq!(batch_events[0]["event"], "batch-distinct-in-properties");
+    assert_eq!(batch_events[0]["distinct_id"], "batch-properties-user");
+    assert_eq!(batch_events[0]["group0"], "team-43");
+    assert_eq!(batch_events[0]["group_properties"]["team"]["members"], 7);
+    assert_eq!(batch_events[1]["event"], "$groupidentify");
+    assert_eq!(batch_events[1]["group0"], "team-44");
+    assert_eq!(batch_events[1]["group_properties"]["team"]["members"], 9);
+
+    let browser_group_response = client
+        .post(format!("{}/e", base_url))
+        .json(&json!({
+            "token": "phc_browser_group",
+            "event": "$groupidentify",
+            "properties": {
+                "$distinct_id": "browser-group-user",
+                "$group_type": "team",
+                "$group_key": "team-45",
+                "$group_set": { "members": 11 }
+            }
+        }))
+        .send()
+        .await?;
+    assert!(browser_group_response.status().is_success());
+
+    let browser_group_events = wait_for_events(&mut pipeline_rx).await?;
+    assert_eq!(browser_group_events.len(), 1);
+    assert_eq!(browser_group_events[0]["event"], "$groupidentify");
+    assert_eq!(browser_group_events[0]["group0"], "team-45");
+    assert_eq!(
+        browser_group_events[0]["group_properties"]["team"]["members"],
+        11
+    );
+
+    cleanup(server_handle, pipeline_handle).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn flags_accept_evaluation_contexts_and_implicit_properties(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (pipeline_endpoint, _pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
+    let flags = FeatureFlagStore::from_json(
+        r#"{
+  "group_type_mapping": { "0": "company" },
+  "flags": [
+    {
+      "key": "env-flag",
+      "active": true,
+      "evaluation_environments": ["prod"]
+    },
+    {
+      "key": "distinct-flag",
+      "active": true,
+      "filters": {
+        "groups": [
+          {
+            "properties": [
+              { "key": "distinct_id", "value": "ctx-user", "type": "person", "operator": "exact" }
+            ],
+            "rollout_percentage": 100
+          }
+        ]
+      }
+    },
+    {
+      "key": "group-key-flag",
+      "active": true,
+      "filters": {
+        "aggregation_group_type_index": 0,
+        "groups": [
+          {
+            "properties": [
+              { "key": "$group_key", "value": "acme", "type": "group", "operator": "exact" }
+            ],
+            "rollout_percentage": 100
+          }
+        ]
+      }
+    }
+  ]
+}"#,
+    )?;
+    let (address, server_handle) =
+        spawn_app_with_options(pipeline_endpoint, None, None, None, Some(flags)).await?;
+
+    let base_url = format!("http://{}", address);
+    let client = Client::builder().timeout(Duration::from_secs(5)).build()?;
+    let response = client
+        .post(format!("{}/flags", base_url))
+        .json(&json!({
+            "distinct_id": "ctx-user",
+            "evaluation_contexts": ["prod"],
+            "groups": { "company": "acme" },
+            "group_properties": {
+                "company": { "plan": "pro" }
+            }
+        }))
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    let body: Value = response.json().await?;
+    assert_eq!(body["featureFlags"]["env-flag"], true);
+    assert_eq!(body["featureFlags"]["distinct-flag"], true);
+    assert_eq!(body["featureFlags"]["group-key-flag"], true);
+    assert_eq!(body["errorsWhileComputingFlags"], false);
+
+    let scoped_out = client
+        .post(format!("{}/flags", base_url))
+        .json(&json!({
+            "distinct_id": "ctx-user",
+            "evaluation_contexts": ["dev"]
+        }))
+        .send()
+        .await?;
+    assert!(scoped_out.status().is_success());
+    let scoped_body: Value = scoped_out.json().await?;
+    assert!(scoped_body["featureFlags"].get("env-flag").is_none());
 
     cleanup(server_handle, pipeline_handle).await;
     Ok(())

--- a/tests/posthog_js.rs
+++ b/tests/posthog_js.rs
@@ -4,9 +4,11 @@ mod helpers;
 use std::time::Duration;
 
 use helpers::{
-    cleanup, spawn_app, spawn_app_with_options, spawn_pipeline_stub, start_docker_pipeline,
+    cleanup, collect_events_until, spawn_app, spawn_app_with_options,
+    spawn_app_with_runtime_options, spawn_pipeline_stub, start_docker_pipeline,
     stop_docker_pipeline, wait_for_events, wait_for_pipeline_events,
 };
+use hogflare::groups::GroupTypeMap;
 use reqwest::Client;
 use serde_json::Value;
 use tokio::process::Command;
@@ -155,6 +157,71 @@ async fn posthog_js_identify_is_forwarded_to_pipeline() -> Result<(), Box<dyn st
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn posthog_js_identify_aliases_anonymous_id_with_sdk_payload(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let debug_token = "debug-js-sdk-identify";
+    let anon_id = "anonymous-sdk-user";
+    let identified_id = "identified-sdk-user";
+    let (pipeline_endpoint, mut pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
+    let (address, server_handle) = spawn_app_with_runtime_options(
+        pipeline_endpoint,
+        None,
+        None,
+        None,
+        Some(debug_token.to_string()),
+        None,
+        GroupTypeMap::default(),
+    )
+    .await?;
+
+    let status = Command::new("bun")
+        .arg("run")
+        .arg("posthog_identify_alias.js")
+        .current_dir("tests/js_client")
+        .env("HOGFLARE_HOST", format!("http://{}", address))
+        .env("HOGFLARE_API_KEY", "phc_test_integration_key")
+        .env("HOGFLARE_ANON_DISTINCT_ID", anon_id)
+        .env("HOGFLARE_IDENTIFIED_ID", identified_id)
+        .status()
+        .await?;
+
+    if !status.success() {
+        return Err(format!("posthog identify alias script exited with status {status:?}").into());
+    }
+
+    let events = collect_events_until(&mut pipeline_rx, 1, Duration::from_secs(10)).await?;
+    let event = events
+        .iter()
+        .find(|e| e["event"] == "$identify")
+        .expect("expected $identify event in pipeline payload");
+
+    assert_eq!(event["source"], "posthog");
+    assert_eq!(event["distinct_id"], identified_id);
+    assert_eq!(
+        event["person_properties"]["email"],
+        "sdk-identify@example.com"
+    );
+
+    let client = Client::builder().timeout(Duration::from_secs(5)).build()?;
+    let snapshot: Value = client
+        .get(format!("http://{}/__debug/person/{}", address, anon_id))
+        .header("x-hogflare-debug-token", debug_token)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    assert_eq!(snapshot["canonical_id"], identified_id);
+    assert_eq!(
+        snapshot["record"]["properties"]["email"],
+        "sdk-identify@example.com"
+    );
+
+    cleanup(server_handle, pipeline_handle).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn posthog_js_group_is_forwarded_to_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     let (pipeline_endpoint, mut pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
     let (address, server_handle) = spawn_app(pipeline_endpoint).await?;
@@ -182,6 +249,70 @@ async fn posthog_js_group_is_forwarded_to_pipeline() -> Result<(), Box<dyn std::
     assert_eq!(event["source"], "posthog");
     assert_eq!(event["extra"]["group_type"], "company");
     assert_eq!(event["extra"]["group_key"], "acme-corp");
+
+    cleanup(server_handle, pipeline_handle).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn posthog_js_compressed_group_flow_hydrates_followup_capture(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (pipeline_endpoint, mut pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
+    let group_type_map = GroupTypeMap::new([Some("company".to_string()), None, None, None, None]);
+    let (address, server_handle) = spawn_app_with_runtime_options(
+        pipeline_endpoint,
+        None,
+        None,
+        None,
+        None,
+        None,
+        group_type_map,
+    )
+    .await?;
+
+    let status = Command::new("bun")
+        .arg("run")
+        .arg("posthog_compressed_group_flow.js")
+        .current_dir("tests/js_client")
+        .env("HOGFLARE_HOST", format!("http://{}", address))
+        .env("HOGFLARE_API_KEY", "phc_test_integration_key")
+        .env("HOGFLARE_DISTINCT_ID", "js-compressed-group-user")
+        .status()
+        .await?;
+
+    if !status.success() {
+        return Err(
+            format!("posthog compressed group script exited with status {status:?}").into(),
+        );
+    }
+
+    let events = collect_events_until(&mut pipeline_rx, 2, Duration::from_secs(10)).await?;
+    let group_event = events
+        .iter()
+        .find(|e| e["event"] == "$groupidentify")
+        .expect("expected $groupidentify event in pipeline payload");
+    assert_eq!(group_event["source"], "posthog");
+    assert_eq!(group_event["extra"]["group_type"], "company");
+    assert_eq!(group_event["extra"]["group_key"], "sdk-acme");
+    assert_eq!(group_event["group0"], "sdk-acme");
+    assert_eq!(
+        group_event["group_properties"]["company"]["plan"],
+        "enterprise"
+    );
+    assert_eq!(group_event["group_properties"]["company"]["seats"], 42);
+
+    let capture_event = events
+        .iter()
+        .find(|e| e["event"] == "js-grouped-capture")
+        .expect("expected grouped capture event in pipeline payload");
+    assert_eq!(capture_event["source"], "posthog");
+    assert_eq!(capture_event["distinct_id"], "js-compressed-group-user");
+    assert_eq!(capture_event["group0"], "sdk-acme");
+    assert_eq!(
+        capture_event["group_properties"]["company"]["plan"],
+        "enterprise"
+    );
+    assert_eq!(capture_event["properties"]["client"], "posthog-js");
 
     cleanup(server_handle, pipeline_handle).await;
     Ok(())

--- a/tests/posthog_node.rs
+++ b/tests/posthog_node.rs
@@ -1,14 +1,17 @@
 #[path = "helpers/mod.rs"]
 mod helpers;
 
-use helpers::{cleanup, spawn_app, spawn_app_with_options, spawn_pipeline_stub, wait_for_events};
+use helpers::{
+    cleanup, collect_events_until, spawn_app, spawn_app_with_options,
+    spawn_app_with_runtime_options, spawn_pipeline_stub, wait_for_events,
+};
 use hogflare::feature_flags::FeatureFlagStore;
+use hogflare::groups::GroupTypeMap;
 use serde_json::Value;
 use tokio::process::Command;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn posthog_node_capture_is_forwarded_to_pipeline() -> Result<(), Box<dyn std::error::Error>>
-{
+async fn posthog_node_capture_is_forwarded_to_pipeline() -> Result<(), Box<dyn std::error::Error>> {
     let (pipeline_endpoint, mut pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
     let (address, server_handle) = spawn_app(pipeline_endpoint).await?;
 
@@ -49,8 +52,70 @@ async fn posthog_node_capture_is_forwarded_to_pipeline() -> Result<(), Box<dyn s
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn posthog_node_feature_flags_are_evaluated(
+async fn posthog_node_group_identify_and_grouped_capture_use_sdk_shapes(
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let (pipeline_endpoint, mut pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
+    let group_type_map = GroupTypeMap::new([Some("company".to_string()), None, None, None, None]);
+    let (address, server_handle) = spawn_app_with_runtime_options(
+        pipeline_endpoint,
+        None,
+        None,
+        None,
+        None,
+        None,
+        group_type_map,
+    )
+    .await?;
+
+    let status = Command::new("bun")
+        .arg("run")
+        .arg("posthog_node_group_flow.js")
+        .current_dir("tests/js_client")
+        .env("HOGFLARE_HOST", format!("http://{}", address))
+        .env("HOGFLARE_API_KEY", "phc_test_node_key")
+        .env("HOGFLARE_DISTINCT_ID", "node-group-user")
+        .status()
+        .await?;
+
+    if !status.success() {
+        return Err(format!("posthog node group script exited with status {status:?}").into());
+    }
+
+    let events =
+        collect_events_until(&mut pipeline_rx, 2, std::time::Duration::from_secs(10)).await?;
+    let group_event = events
+        .iter()
+        .find(|event| event["event"] == "$groupidentify")
+        .expect("expected node $groupidentify event in pipeline payload");
+    assert_eq!(group_event["source"], "posthog");
+    assert_eq!(group_event["extra"]["group_type"], "company");
+    assert_eq!(group_event["extra"]["group_key"], "node-acme");
+    assert_eq!(group_event["group0"], "node-acme");
+    assert_eq!(
+        group_event["group_properties"]["company"]["plan"],
+        "enterprise"
+    );
+    assert_eq!(group_event["group_properties"]["company"]["seats"], 12);
+
+    let capture_event = events
+        .iter()
+        .find(|event| event["event"] == "node-grouped-capture")
+        .expect("expected node grouped capture event in pipeline payload");
+    assert_eq!(capture_event["source"], "posthog");
+    assert_eq!(capture_event["distinct_id"], "node-group-user");
+    assert_eq!(capture_event["group0"], "node-acme");
+    assert_eq!(
+        capture_event["group_properties"]["company"]["plan"],
+        "enterprise"
+    );
+    assert_eq!(capture_event["properties"]["client"], "posthog-node");
+
+    cleanup(server_handle, pipeline_handle).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn posthog_node_feature_flags_are_evaluated() -> Result<(), Box<dyn std::error::Error>> {
     let (pipeline_endpoint, _pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
     let flags = FeatureFlagStore::from_json(
         r#"{
@@ -73,14 +138,8 @@ async fn posthog_node_feature_flags_are_evaluated(
 }"#,
     )?;
 
-    let (address, server_handle) = spawn_app_with_options(
-        pipeline_endpoint,
-        None,
-        None,
-        None,
-        Some(flags),
-    )
-    .await?;
+    let (address, server_handle) =
+        spawn_app_with_options(pipeline_endpoint, None, None, None, Some(flags)).await?;
 
     let output = Command::new("bun")
         .arg("run")
@@ -110,8 +169,122 @@ async fn posthog_node_feature_flags_are_evaluated(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn posthog_node_flags_update_after_capture(
+async fn posthog_node_official_flag_shapes_match_sdk_remote_evaluation(
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let (pipeline_endpoint, _pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
+    let flags = FeatureFlagStore::from_json(
+        r#"{
+  "group_type_mapping": { "0": "company" },
+  "flags": [
+    {
+      "key": "sdk-distinct-flag",
+      "active": true,
+      "filters": {
+        "groups": [
+          {
+            "properties": [
+              { "key": "distinct_id", "value": "node-official-flag-user", "type": "person", "operator": "exact" }
+            ],
+            "rollout_percentage": 100
+          }
+        ]
+      }
+    },
+    {
+      "key": "sdk-group-key-flag",
+      "active": true,
+      "filters": {
+        "aggregation_group_type_index": 0,
+        "groups": [
+          {
+            "properties": [
+              { "key": "$group_key", "value": "node-flags-company", "type": "group", "operator": "exact" }
+            ],
+            "rollout_percentage": 100
+          }
+        ]
+      }
+    },
+    {
+      "key": "sdk-group-plan-flag",
+      "active": true,
+      "filters": {
+        "aggregation_group_type_index": 0,
+        "groups": [
+          {
+            "properties": [
+              { "key": "plan", "value": "enterprise", "type": "group", "operator": "exact" }
+            ],
+            "rollout_percentage": 100
+          }
+        ]
+      }
+    },
+    {
+      "key": "sdk-variant-flag",
+      "active": true,
+      "filters": {
+        "groups": [
+          { "properties": [], "rollout_percentage": 100 }
+        ],
+        "multivariate": {
+          "variants": [
+            { "key": "control", "rollout_percentage": 0 },
+            { "key": "test", "rollout_percentage": 100 }
+          ]
+        },
+        "payloads": { "test": "{\"copy\":\"sdk\"}" }
+      }
+    }
+  ]
+}"#,
+    )?;
+
+    let group_type_map = GroupTypeMap::new([Some("company".to_string()), None, None, None, None]);
+    let (address, server_handle) = spawn_app_with_runtime_options(
+        pipeline_endpoint,
+        None,
+        None,
+        None,
+        None,
+        Some(flags),
+        group_type_map,
+    )
+    .await?;
+
+    let output = Command::new("bun")
+        .arg("run")
+        .arg("posthog_node_official_flags.js")
+        .current_dir("tests/js_client")
+        .env("HOGFLARE_HOST", format!("http://{}", address))
+        .env("HOGFLARE_API_KEY", "phc_test_node_key")
+        .env("HOGFLARE_DISTINCT_ID", "node-official-flag-user")
+        .env("HOGFLARE_GROUP_KEY", "node-flags-company")
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "posthog node official flags script exited with status {:?}",
+            output.status
+        )
+        .into());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let result: Value = serde_json::from_str(stdout.trim())?;
+    assert_eq!(result["distinct"], Value::Bool(true));
+    assert_eq!(result["groupKeyFlag"], Value::Bool(true));
+    assert_eq!(result["groupPlan"], Value::Bool(true));
+    assert_eq!(result["variant"], Value::String("test".to_string()));
+    assert_eq!(result["payload"]["copy"], Value::String("sdk".to_string()));
+
+    cleanup(server_handle, pipeline_handle).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn posthog_node_flags_update_after_capture() -> Result<(), Box<dyn std::error::Error>> {
     let (pipeline_endpoint, _pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
     let flags = FeatureFlagStore::from_json(
         r#"{
@@ -134,14 +307,8 @@ async fn posthog_node_flags_update_after_capture(
 }"#,
     )?;
 
-    let (address, server_handle) = spawn_app_with_options(
-        pipeline_endpoint,
-        None,
-        None,
-        None,
-        Some(flags),
-    )
-    .await?;
+    let (address, server_handle) =
+        spawn_app_with_options(pipeline_endpoint, None, None, None, Some(flags)).await?;
 
     let output = Command::new("bun")
         .arg("run")

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -20,8 +20,8 @@ class_name = "GroupDurableObject"
 
 [[migrations]]
 tag = "v1"
-new_classes = ["PersonDurableObject"]
+new_sqlite_classes = ["PersonDurableObject"]
 
 [[migrations]]
 tag = "v2"
-new_classes = ["PersonIdCounterDurableObject", "GroupDurableObject"]
+new_sqlite_classes = ["PersonIdCounterDurableObject", "GroupDurableObject"]


### PR DESCRIPTION
Fixes Hogflare PostHog compatibility across browser ingestion, group state, durable person state, and feature flag evaluation.

Changes include:
- route /e, /flags, and /decide through shared signed/encoded PostHog payload parsing, including current browser SDK gzip-js and base64 forms
- preserve browser identify anonymous linking via $anon_distinct_id
- normalize documented $groupidentify and /batch shapes across raw HTTP, posthog-js, and posthog-node flows
- persist and hydrate group state with collision-safe group object naming
- move durable person ensure/update/alias flows into object-owned endpoints with bounded redirect resolution
- align feature flag parsing, bucketing, group flags, payloads, evaluation contexts, and response field types with current PostHog SDK behavior
- update Cloudflare Durable Object migration examples to SQLite-backed classes
- add SDK-driven integration coverage using posthog-js 1.373.4 and posthog-node 5.34.1

Validation:
- cargo fmt --check
- git diff --check
- worker-build --release
- cargo test --all --locked
