### PR TITLE
Add queryable persons pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="hog.png" alt="Hogflare" width="300">
 
-Hogflare is a Cloudflare Workers ingestion layer for PostHog SDKs. It supports PostHog-style ingestion, stateful persons/groups, and SDK feature flags, then streams events into Cloudflare Pipelines so data lands in R2 as Iceberg/Parquet.
+Hogflare is a Cloudflare Workers ingestion layer for PostHog SDKs. It supports PostHog-style ingestion, stateful persons/groups, and SDK feature flags, then streams events and person snapshots into Cloudflare Pipelines so data lands in R2 as Iceberg/Parquet.
 
 #### What works today
 
@@ -10,6 +10,7 @@ Hogflare is a Cloudflare Workers ingestion layer for PostHog SDKs. It supports P
 - Persons and groups: `$set`, `$set_once`, `$unset`, aliasing, and group properties
 - Feature flags: `/flags` and `/decide` are evaluated in the Worker (used by PostHog SDKs)
 - Request enrichment: Cloudflare IP/geo fields added when missing
+- Queryable people: append-only person snapshots can be written to a separate Iceberg table
 
 ## Architecture
 
@@ -34,8 +35,10 @@ flowchart TB
         PersonsDO -.-> PersonIdDO
     end
 
-    Worker -->|"events"| Pipeline["Cloudflare Pipelines"]
-    Pipeline --> R2["R2 Data Catalog<br/>(Iceberg/Parquet)"]
+    Worker -->|"events"| EventsPipeline["Events Pipeline"]
+    Worker -->|"person snapshots"| PersonsPipeline["Persons Pipeline"]
+    EventsPipeline --> EventsR2["R2 Data Catalog<br/>events table"]
+    PersonsPipeline --> PersonsR2["R2 Data Catalog<br/>persons table"]
 ```
 
 ## Why?
@@ -48,44 +51,70 @@ Admittedly, PostHog does a *lot* more than this package, but some folks really j
 
 ## Quick start (Cloudflare)
 
-1) Create a Pipeline stream and sink in the Cloudflare dashboard or via `wrangler pipelines setup`.
-2) Use the schema below for the stream.
-3) Copy `wrangler.toml.example` to `wrangler.toml` and set variables.
-4) Set Wrangler secrets.
-5) Deploy the Worker.
+1. Create R2 Data Catalog-backed Pipelines resources.
+2. Copy `wrangler.toml.example` to `wrangler.toml` and set the stream endpoints.
+3. Set Wrangler secrets.
+4. Build and deploy the Worker.
+5. Send a capture/identify verification flow and query the Iceberg tables.
 
-### Pipeline schema (JSON)
+The examples below use stable table names for a fresh deployment: `default.hogflare_events` and `default.hogflare_persons`. If you use versioned names during migration, substitute those names consistently in the sink commands and queries.
 
-```json
-{
-  "fields": [
-    { "name": "uuid", "type": "string", "required": true },
-    { "name": "team_id", "type": "int64", "required": false },
-    { "name": "source", "type": "string", "required": true },
-    { "name": "event", "type": "string", "required": true },
-    { "name": "distinct_id", "type": "string", "required": true },
-    { "name": "timestamp", "type": "timestamp", "required": false },
-    { "name": "created_at", "type": "timestamp", "required": true },
-    { "name": "properties", "type": "json", "required": false },
-    { "name": "context", "type": "json", "required": false },
-    { "name": "person_id", "type": "string", "required": false },
-    { "name": "person_created_at", "type": "timestamp", "required": false },
-    { "name": "person_properties", "type": "json", "required": false },
-    { "name": "group0", "type": "string", "required": false },
-    { "name": "group1", "type": "string", "required": false },
-    { "name": "group2", "type": "string", "required": false },
-    { "name": "group3", "type": "string", "required": false },
-    { "name": "group4", "type": "string", "required": false },
-    { "name": "group_properties", "type": "json", "required": false },
-    { "name": "api_key", "type": "string", "required": false },
-    { "name": "extra", "type": "json", "required": false }
-  ]
-}
+### Create Pipelines Resources
+
+Set these values before creating sinks:
+
+```bash
+export R2_BUCKET="<bucket-name>"
+export R2_CATALOG_TOKEN="<r2-data-catalog-token>"
 ```
+
+`R2_CATALOG_TOKEN` is the token used by R2 Data Catalog/R2 SQL clients such as DuckDB or PyIceberg. The bucket must have R2 Data Catalog enabled before creating `r2-data-catalog` sinks.
+
+Create the events stream, sink, and pipeline:
+
+```bash
+bunx wrangler pipelines streams create hogflare_events_stream \
+  --schema-file scripts/events-pipeline-schema.json \
+  --http-enabled true \
+  --http-auth true
+
+bunx wrangler pipelines sinks create hogflare_events_sink \
+  --type r2-data-catalog \
+  --bucket "$R2_BUCKET" \
+  --namespace default \
+  --table hogflare_events \
+  --catalog-token "$R2_CATALOG_TOKEN" \
+  --roll-interval 60
+
+bunx wrangler pipelines create hogflare_events_pipeline \
+  --sql "INSERT INTO hogflare_events_sink SELECT * FROM hogflare_events_stream;"
+```
+
+Create the persons stream, sink, and pipeline if you want queryable people in Iceberg:
+
+```bash
+bunx wrangler pipelines streams create hogflare_persons_stream \
+  --schema-file scripts/persons-pipeline-schema.json \
+  --http-enabled true \
+  --http-auth true
+
+bunx wrangler pipelines sinks create hogflare_persons_sink \
+  --type r2-data-catalog \
+  --bucket "$R2_BUCKET" \
+  --namespace default \
+  --table hogflare_persons \
+  --catalog-token "$R2_CATALOG_TOKEN" \
+  --roll-interval 60
+
+bunx wrangler pipelines create hogflare_persons_pipeline \
+  --sql "INSERT INTO hogflare_persons_sink SELECT * FROM hogflare_persons_stream;"
+```
+
+Each stream creation command prints an HTTP endpoint like `https://<stream-id>.ingest.cloudflare.com`. Use those endpoints in `wrangler.toml`.
 
 ### Wrangler config
 
-Copy the example and fill in your stream endpoint:
+Copy the example and fill in the stream endpoints:
 
 ```bash
 cp wrangler.toml.example wrangler.toml
@@ -98,6 +127,7 @@ compatibility_date = "2025-01-09"
 
 [vars]
 CLOUDFLARE_PIPELINE_ENDPOINT = "https://<stream-id>.ingest.cloudflare.com"
+CLOUDFLARE_PERSONS_PIPELINE_ENDPOINT = "https://<persons-stream-id>.ingest.cloudflare.com"
 CLOUDFLARE_PIPELINE_TIMEOUT_SECS = "10"
 
 # Optional
@@ -129,33 +159,119 @@ tag = "v2"
 new_sqlite_classes = ["PersonIdCounterDurableObject", "GroupDurableObject"]
 ```
 
+### Configuration Reference
+
+| Setting | Required | Notes |
+| --- | --- | --- |
+| `CLOUDFLARE_PIPELINE_ENDPOINT` | Yes | Events stream HTTP endpoint from `wrangler pipelines streams create`. |
+| `CLOUDFLARE_PIPELINE_AUTH_TOKEN` | Yes, for authenticated streams | Bearer token used for events stream HTTP ingest. |
+| `CLOUDFLARE_PERSONS_PIPELINE_ENDPOINT` | No | Persons stream endpoint. Set this to write person snapshots to Iceberg. |
+| `CLOUDFLARE_PERSONS_PIPELINE_AUTH_TOKEN` | No | Falls back to `CLOUDFLARE_PIPELINE_AUTH_TOKEN` when omitted. |
+| `CLOUDFLARE_PIPELINE_TIMEOUT_SECS` | No | Defaults to 10 seconds. |
+| `POSTHOG_API_KEY` | No | Default project token returned by `/decide` when request/header token is absent. |
+| `POSTHOG_TEAM_ID` | No | Optional team id attached to event and person rows. |
+| `POSTHOG_GROUP_TYPE_0..4` | No | Maps PostHog group types to `group0..group4`; set `POSTHOG_GROUP_TYPE_0=company` to populate `group0` for company groups. |
+| `POSTHOG_SESSION_RECORDING_ENDPOINT` | No | Returned in `/decide` session recording config. |
+| `POSTHOG_SIGNING_SECRET` | No | Enables HMAC request signature checks. |
+| `PERSON_DEBUG_TOKEN` | No | Enables `/__debug/person/:id` for deployment verification. |
+| `HOGFLARE_FEATURE_FLAGS` | No | JSON flag config used by `/decide` and `/flags`. |
+
 ### Secrets
+
+Use a Cloudflare API token that can write to Pipelines for `CLOUDFLARE_PIPELINE_AUTH_TOKEN`. The same token can usually be reused for the persons stream.
 
 ```bash
 bunx wrangler secret put CLOUDFLARE_PIPELINE_AUTH_TOKEN
+# Optional. If omitted, the persons pipeline uses CLOUDFLARE_PIPELINE_AUTH_TOKEN.
+bunx wrangler secret put CLOUDFLARE_PERSONS_PIPELINE_AUTH_TOKEN
+
+# Optional.
 bunx wrangler secret put POSTHOG_SIGNING_SECRET
+bunx wrangler secret put PERSON_DEBUG_TOKEN
+bunx wrangler secret put HOGFLARE_FEATURE_FLAGS
 ```
 
 ### Deploy
 
 ```bash
+worker-build --release
 bunx wrangler deploy
 ```
 
-## Send a test event
+## Verify Deployment
 
 ```bash
-curl -X POST https://<your-worker>.workers.dev/capture \
-  -H "Content-Type: application/json" \
-  -d '[
-    {
-      "api_key": "phc_example",
-      "event": "purchase",
-      "distinct_id": "user_12345",
-      "properties": { "amount": 29.99, "product_id": "widget-001" }
-    }
-  ]'
+export HOGFLARE_URL="https://<your-worker>.workers.dev"
+export HOGFLARE_API_KEY="phc_verify_$(date -u +%Y%m%d%H%M%S)"
+export HOGFLARE_ANON_ID="${HOGFLARE_API_KEY}_anon"
+export HOGFLARE_USER_ID="${HOGFLARE_API_KEY}_user"
 ```
+
+Send an anonymous capture:
+
+```bash
+curl -X POST "$HOGFLARE_URL/capture" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"api_key\": \"$HOGFLARE_API_KEY\",
+    \"event\": \"verify-anon-capture\",
+    \"distinct_id\": \"$HOGFLARE_ANON_ID\",
+    \"properties\": {
+      \"\$set\": { \"initial_referrer\": \"docs\" },
+      \"\$set_once\": { \"first_seen_source\": \"readme\" }
+    }
+  }"
+```
+
+Identify the user and link the anonymous ID:
+
+```bash
+curl -X POST "$HOGFLARE_URL/identify" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"api_key\": \"$HOGFLARE_API_KEY\",
+    \"distinct_id\": \"$HOGFLARE_USER_ID\",
+    \"properties\": {
+      \"\$anon_distinct_id\": \"$HOGFLARE_ANON_ID\",
+      \"\$set\": { \"email\": \"verify@example.com\", \"plan\": \"pro\" },
+      \"\$set_once\": { \"signup_source\": \"readme\" }
+    }
+  }"
+```
+
+Send a post-identify capture:
+
+```bash
+curl -X POST "$HOGFLARE_URL/capture" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"api_key\": \"$HOGFLARE_API_KEY\",
+    \"event\": \"verify-identified-capture\",
+    \"distinct_id\": \"$HOGFLARE_USER_ID\",
+    \"properties\": { \"button\": \"verify\" }
+  }"
+```
+
+Wait for the sink roll interval, then query R2 SQL:
+
+```bash
+export R2_WAREHOUSE="<account-id>_<bucket-name>"
+export WRANGLER_R2_SQL_AUTH_TOKEN="$R2_CATALOG_TOKEN"
+
+bunx wrangler r2 sql query "$R2_WAREHOUSE" \
+  "select event, distinct_id, person_id, person_properties
+   from default.hogflare_events
+   where api_key = '$HOGFLARE_API_KEY'
+   order by created_at asc"
+
+bunx wrangler r2 sql query "$R2_WAREHOUSE" \
+  "select operation, canonical_distinct_id, person_id, distinct_ids, merged_properties
+   from default.hogflare_persons
+   where api_key = '$HOGFLARE_API_KEY'
+   order by updated_at asc"
+```
+
+Expected result: the three event rows share one `person_id`, and the persons table has `capture`, `identify`, `capture` snapshots. After identify, `distinct_ids` should include both the anonymous and identified IDs.
 
 ## HMAC signing (optional)
 
@@ -227,6 +343,7 @@ docker compose up --build -d fake-pipeline
 ```bash
 # .env.local (not committed)
 CLOUDFLARE_PIPELINE_ENDPOINT=http://127.0.0.1:8088/
+CLOUDFLARE_PERSONS_PIPELINE_ENDPOINT=http://127.0.0.1:8088/
 CLOUDFLARE_PIPELINE_TIMEOUT_SECS=5
 ```
 
@@ -252,8 +369,44 @@ ATTACH '<ACCOUNT_ID>_<BUCKET>' AS iceberg_catalog (
   ENDPOINT 'https://catalog.cloudflarestorage.com/<ACCOUNT_ID>/<BUCKET>'
 );
 
-SELECT count(*) FROM iceberg_catalog.default.hogflare;
-SELECT * FROM iceberg_catalog.default.hogflare LIMIT 5;
+SELECT count(*) FROM iceberg_catalog.default.hogflare_events;
+SELECT count(*) FROM iceberg_catalog.default.hogflare_persons;
+SELECT * FROM iceberg_catalog.default.hogflare_persons LIMIT 5;
+```
+
+If you used versioned table names during a migration, substitute those names here.
+
+## Cleanup
+
+Delete Pipelines resources in dependency order: pipelines first, then streams and sinks.
+
+```bash
+bunx wrangler pipelines list
+bunx wrangler pipelines delete <pipeline-id> --force
+
+bunx wrangler pipelines streams list
+bunx wrangler pipelines streams delete <stream-id> --force
+
+bunx wrangler pipelines sinks list
+bunx wrangler pipelines sinks delete <sink-id> --force
+```
+
+`wrangler r2 sql query` is read-only. To drop an Iceberg table from R2 Data Catalog, use the Iceberg catalog API. One local option is PyIceberg:
+
+```bash
+R2_CATALOG_TOKEN="<r2-data-catalog-token>" uv run --with pyiceberg python - <<'PY'
+import os
+from pyiceberg.catalog.rest import RestCatalog
+
+catalog = RestCatalog(
+    name="hogflare",
+    warehouse="<account-id>_<bucket-name>",
+    uri="https://catalog.cloudflarestorage.com/<account-id>/<bucket-name>",
+    token=os.environ["R2_CATALOG_TOKEN"],
+)
+
+catalog.drop_table(("default", "<table-name>"), purge_requested=True)
+PY
 ```
 
 ## PostHog compatibility
@@ -276,7 +429,7 @@ Identify, capture `$set` / `$set_once` / `$unset`, and alias events update a per
 - `person_created_at`
 - `person_properties`
 
-Person DO state is not written to R2. Only event-level snapshots are stored in the pipeline sink.
+The Durable Object is the source of truth for the current person record. When `CLOUDFLARE_PERSONS_PIPELINE_ENDPOINT` is configured, Hogflare also writes append-only person snapshots to the persons pipeline so the state is queryable in Iceberg.
 
 ### Groups
 
@@ -403,3 +556,26 @@ Each row is a `PipelineEvent` with these columns:
 | `group_properties` | JSON (by group type) |
 | `api_key` | string |
 | `extra` | JSON |
+
+## Person shape in R2
+
+Each row is a `PersonPipelineRecord` snapshot with these columns:
+
+| Field | Type / Notes |
+| --- | --- |
+| `uuid` | string (snapshot UUID v4) |
+| `team_id` | int64 (optional) |
+| `source` | string |
+| `operation` | capture, identify, alias, engage, session_recording |
+| `person_id` | string (person UUID) |
+| `person_int_id` | int64 |
+| `canonical_distinct_id` | string |
+| `distinct_ids` | string list / array |
+| `created_at` | person creation timestamp |
+| `updated_at` | snapshot timestamp |
+| `version` | person version |
+| `properties` | JSON `$set` properties |
+| `properties_set_once` | JSON `$set_once` properties |
+| `merged_properties` | JSON merged person properties |
+| `api_key` | string |
+| `source_event_uuid` | event row UUID that produced the snapshot |

--- a/scripts/events-pipeline-schema.json
+++ b/scripts/events-pipeline-schema.json
@@ -1,0 +1,24 @@
+{
+  "fields": [
+    { "name": "uuid", "type": "string", "required": true },
+    { "name": "team_id", "type": "int64", "required": false },
+    { "name": "source", "type": "string", "required": true },
+    { "name": "event", "type": "string", "required": true },
+    { "name": "distinct_id", "type": "string", "required": true },
+    { "name": "timestamp", "type": "timestamp", "required": false },
+    { "name": "created_at", "type": "timestamp", "required": true },
+    { "name": "properties", "type": "json", "required": false },
+    { "name": "context", "type": "json", "required": false },
+    { "name": "person_id", "type": "string", "required": false },
+    { "name": "person_created_at", "type": "timestamp", "required": false },
+    { "name": "person_properties", "type": "json", "required": false },
+    { "name": "group0", "type": "string", "required": false },
+    { "name": "group1", "type": "string", "required": false },
+    { "name": "group2", "type": "string", "required": false },
+    { "name": "group3", "type": "string", "required": false },
+    { "name": "group4", "type": "string", "required": false },
+    { "name": "group_properties", "type": "json", "required": false },
+    { "name": "api_key", "type": "string", "required": false },
+    { "name": "extra", "type": "json", "required": false }
+  ]
+}

--- a/scripts/persons-pipeline-schema.json
+++ b/scripts/persons-pipeline-schema.json
@@ -1,0 +1,25 @@
+{
+  "fields": [
+    { "name": "uuid", "type": "string", "required": true },
+    { "name": "team_id", "type": "int64", "required": false },
+    { "name": "source", "type": "string", "required": true },
+    { "name": "operation", "type": "string", "required": true },
+    { "name": "person_id", "type": "string", "required": true },
+    { "name": "person_int_id", "type": "int64", "required": true },
+    { "name": "canonical_distinct_id", "type": "string", "required": true },
+    {
+      "name": "distinct_ids",
+      "type": "list",
+      "required": true,
+      "items": { "type": "string" }
+    },
+    { "name": "created_at", "type": "timestamp", "required": true },
+    { "name": "updated_at", "type": "timestamp", "required": true },
+    { "name": "version", "type": "int64", "required": true },
+    { "name": "properties", "type": "json", "required": true },
+    { "name": "properties_set_once", "type": "json", "required": true },
+    { "name": "merged_properties", "type": "json", "required": true },
+    { "name": "api_key", "type": "string", "required": false },
+    { "name": "source_event_uuid", "type": "string", "required": true }
+  ]
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub address: SocketAddr,
     pub pipeline_endpoint: Url,
     pub pipeline_auth_token: Option<String>,
+    pub persons_pipeline_endpoint: Option<Url>,
+    pub persons_pipeline_auth_token: Option<String>,
     pub pipeline_timeout: Duration,
     pub posthog_team_id: Option<i64>,
     pub posthog_group_types: [Option<String>; 5],
@@ -69,6 +71,30 @@ impl Config {
                     .ok()
                     .map(|var| var.to_string())
             });
+
+        let persons_pipeline_endpoint = match env.var("CLOUDFLARE_PERSONS_PIPELINE_ENDPOINT") {
+            Ok(value) => {
+                let raw = value.to_string();
+                Some(
+                    Url::parse(&raw).map_err(|err| ConfigError::InvalidEndpoint {
+                        value: raw,
+                        message: err.to_string(),
+                    })?,
+                )
+            }
+            Err(_) => None,
+        };
+
+        let persons_pipeline_auth_token = env
+            .secret("CLOUDFLARE_PERSONS_PIPELINE_AUTH_TOKEN")
+            .ok()
+            .map(|secret| secret.to_string())
+            .or_else(|| {
+                env.var("CLOUDFLARE_PERSONS_PIPELINE_AUTH_TOKEN")
+                    .ok()
+                    .map(|var| var.to_string())
+            })
+            .or_else(|| pipeline_auth_token.clone());
 
         let pipeline_timeout = match env.var("CLOUDFLARE_PIPELINE_TIMEOUT_SECS") {
             Ok(value) => value
@@ -135,6 +161,8 @@ impl Config {
             address,
             pipeline_endpoint,
             pipeline_auth_token,
+            persons_pipeline_endpoint,
+            persons_pipeline_auth_token,
             pipeline_timeout,
             posthog_team_id,
             posthog_group_types,
@@ -169,6 +197,25 @@ impl Config {
             })?;
 
         let pipeline_auth_token = env::var("CLOUDFLARE_PIPELINE_AUTH_TOKEN").ok();
+
+        let persons_pipeline_endpoint = match env::var("CLOUDFLARE_PERSONS_PIPELINE_ENDPOINT") {
+            Ok(value) => Some(
+                Url::parse(&value).map_err(|err| ConfigError::InvalidEndpoint {
+                    value,
+                    message: err.to_string(),
+                })?,
+            ),
+            Err(VarError::NotPresent) => None,
+            Err(VarError::NotUnicode(_)) => {
+                return Err(ConfigError::InvalidEndpoint {
+                    value: "<invalid-unicode>".to_string(),
+                    message: "value contains invalid unicode".to_string(),
+                })
+            }
+        };
+        let persons_pipeline_auth_token = env::var("CLOUDFLARE_PERSONS_PIPELINE_AUTH_TOKEN")
+            .ok()
+            .or_else(|| pipeline_auth_token.clone());
 
         let pipeline_timeout = match env::var("CLOUDFLARE_PIPELINE_TIMEOUT_SECS") {
             Ok(value) => value
@@ -232,6 +279,8 @@ impl Config {
             address,
             pipeline_endpoint,
             pipeline_auth_token,
+            persons_pipeline_endpoint,
+            persons_pipeline_auth_token,
             pipeline_timeout,
             posthog_team_id,
             posthog_group_types,

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -857,6 +857,7 @@ mod tests {
 
         AppState {
             pipeline: Arc::new(pipeline),
+            persons_pipeline: None,
             posthog_team_id: None,
             decide_api_token: None,
             session_recording_endpoint: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use persons::{
     alias_from_request, update_from_capture, update_from_engage, update_from_identify,
     NoopPersonStore, PersonAlias, PersonError, PersonStore, PersonUpdate,
 };
-use pipeline::{PipelineClient, PipelineError, PipelineEvent};
+use pipeline::{PersonPipelineRecord, PipelineClient, PipelineError, PipelineEvent};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use thiserror::Error;
@@ -56,6 +56,7 @@ use tower_service::Service;
 #[derive(Clone)]
 pub(crate) struct AppState {
     pub(crate) pipeline: Arc<PipelineClient>,
+    pub(crate) persons_pipeline: Option<Arc<PipelineClient>>,
     pub(crate) posthog_team_id: Option<i64>,
     pub(crate) decide_api_token: Option<String>,
     pub(crate) session_recording_endpoint: Option<String>,
@@ -155,6 +156,18 @@ pub async fn run_with_config(config: Config) -> Result<(), RunError> {
         config.pipeline_auth_token.clone(),
         config.pipeline_timeout,
     )?;
+    let persons_pipeline = config
+        .persons_pipeline_endpoint
+        .as_ref()
+        .map(|endpoint| {
+            PipelineClient::new(
+                endpoint.clone(),
+                config.persons_pipeline_auth_token.clone(),
+                config.pipeline_timeout,
+            )
+            .map(Arc::new)
+        })
+        .transpose()?;
 
     info!(
         endpoint = %config.pipeline_endpoint,
@@ -162,13 +175,22 @@ pub async fn run_with_config(config: Config) -> Result<(), RunError> {
         timeout_secs = config.pipeline_timeout.as_secs(),
         "pipeline client configured"
     );
+    if let Some(endpoint) = config.persons_pipeline_endpoint.as_ref() {
+        info!(
+            endpoint = %endpoint,
+            auth_configured = config.persons_pipeline_auth_token.is_some(),
+            timeout_secs = config.pipeline_timeout.as_secs(),
+            "persons pipeline client configured"
+        );
+    }
 
     let listener = TcpListener::bind(config.address).await?;
     info!(address = %config.address, "listening for requests");
 
-    serve_with_options(
+    serve_with_person_pipeline(
         listener,
         Arc::new(pipeline),
+        persons_pipeline,
         config.posthog_team_id,
         Arc::new(NoopGroupStore),
         GroupTypeMap::new(config.posthog_group_types.clone()),
@@ -214,14 +236,33 @@ pub async fn fetch(
             return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
         }
     };
+    let persons_pipeline = match config.persons_pipeline_endpoint.as_ref() {
+        Some(endpoint) => match PipelineClient::new(
+            endpoint.clone(),
+            config.persons_pipeline_auth_token.clone(),
+            config.pipeline_timeout,
+        ) {
+            Ok(client) => Some(Arc::new(client)),
+            Err(err) => {
+                error!(error = %err, "failed to create persons pipeline client");
+                let body = Json(ErrorResponse {
+                    status: 0,
+                    error: err.to_string(),
+                });
+                return Ok((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
+            }
+        },
+        None => None,
+    };
 
     let person_store: Arc<dyn PersonStore> = persons::store_from_env(&env, config.posthog_team_id);
     let group_store: Arc<dyn GroupStore> = groups::store_from_env(&env);
     let group_type_map = GroupTypeMap::new(config.posthog_group_types.clone());
     let feature_flags = Arc::new(config.feature_flags);
 
-    let mut router = build_router_with_options(
+    let mut router = build_router_with_person_pipeline(
         Arc::new(pipeline),
+        persons_pipeline,
         config.posthog_team_id,
         group_store,
         group_type_map,
@@ -263,8 +304,37 @@ pub fn build_router_with_options(
     feature_flags: Arc<FeatureFlagStore>,
     person_store: Arc<dyn PersonStore>,
 ) -> Router {
+    build_router_with_person_pipeline(
+        pipeline,
+        None,
+        posthog_team_id,
+        group_store,
+        group_type_map,
+        decide_api_token,
+        session_recording_endpoint,
+        signing_secret,
+        person_debug_token,
+        feature_flags,
+        person_store,
+    )
+}
+
+pub fn build_router_with_person_pipeline(
+    pipeline: Arc<PipelineClient>,
+    persons_pipeline: Option<Arc<PipelineClient>>,
+    posthog_team_id: Option<i64>,
+    group_store: Arc<dyn GroupStore>,
+    group_type_map: GroupTypeMap,
+    decide_api_token: Option<String>,
+    session_recording_endpoint: Option<String>,
+    signing_secret: Option<String>,
+    person_debug_token: Option<String>,
+    feature_flags: Arc<FeatureFlagStore>,
+    person_store: Arc<dyn PersonStore>,
+) -> Router {
     router(build_state(
         pipeline,
+        persons_pipeline,
         posthog_team_id,
         group_store,
         group_type_map,
@@ -283,6 +353,7 @@ pub async fn serve(listener: TcpListener, pipeline: Arc<PipelineClient>) -> Resu
         listener,
         build_state(
             pipeline,
+            None,
             None,
             Arc::new(NoopGroupStore),
             GroupTypeMap::default(),
@@ -310,8 +381,39 @@ pub async fn serve_with_options(
     person_debug_token: Option<String>,
     feature_flags: Arc<FeatureFlagStore>,
 ) -> Result<(), RunError> {
+    serve_with_person_pipeline(
+        listener,
+        pipeline,
+        None,
+        posthog_team_id,
+        group_store,
+        group_type_map,
+        decide_api_token,
+        session_recording_endpoint,
+        signing_secret,
+        person_debug_token,
+        feature_flags,
+    )
+    .await
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn serve_with_person_pipeline(
+    listener: TcpListener,
+    pipeline: Arc<PipelineClient>,
+    persons_pipeline: Option<Arc<PipelineClient>>,
+    posthog_team_id: Option<i64>,
+    group_store: Arc<dyn GroupStore>,
+    group_type_map: GroupTypeMap,
+    decide_api_token: Option<String>,
+    session_recording_endpoint: Option<String>,
+    signing_secret: Option<String>,
+    person_debug_token: Option<String>,
+    feature_flags: Arc<FeatureFlagStore>,
+) -> Result<(), RunError> {
     let state = build_state(
         pipeline,
+        persons_pipeline,
         posthog_team_id,
         group_store,
         group_type_map,
@@ -357,6 +459,7 @@ fn router(state: AppState) -> Router {
 
 fn build_state(
     pipeline: Arc<PipelineClient>,
+    persons_pipeline: Option<Arc<PipelineClient>>,
     posthog_team_id: Option<i64>,
     group_store: Arc<dyn GroupStore>,
     group_type_map: GroupTypeMap,
@@ -369,6 +472,7 @@ fn build_state(
 ) -> AppState {
     AppState {
         pipeline,
+        persons_pipeline,
         posthog_team_id,
         group_store,
         group_type_map,
@@ -411,6 +515,7 @@ async fn capture(
     let sent_at = payload.sent_at.clone();
     let enrichment = enrichment.properties();
     let mut events = Vec::new();
+    let mut person_records = Vec::new();
 
     for item in payload.items {
         if item.event == "$groupidentify" {
@@ -477,16 +582,17 @@ async fn capture(
         };
 
         let (person_id, person_created_at, person_properties) = person_fields(&snapshot);
-        events.push(
-            PipelineEvent::from_capture(item)
-                .with_team_id(state.posthog_team_id)
-                .with_person(person_id, person_created_at, person_properties)
-                .with_groups(group_slots, group_properties)
-                .with_sent_at(sent_at.clone())
-                .with_enrichment(enrichment),
-        );
+        let event = PipelineEvent::from_capture(item)
+            .with_team_id(state.posthog_team_id)
+            .with_person(person_id, person_created_at, person_properties)
+            .with_groups(group_slots, group_properties)
+            .with_sent_at(sent_at.clone())
+            .with_enrichment(enrichment);
+        push_person_record(&mut person_records, &snapshot, "capture", &event);
+        events.push(event);
     }
 
+    send_person_records(&state, person_records).await?;
     state.pipeline.send(events).await?;
     Ok(Json(PostHogResponse::success()))
 }
@@ -536,35 +642,21 @@ async fn browser_capture(
     let sent_at = payload.sent_at.clone();
     let enrichment = enrichment.properties();
     let mut events = Vec::new();
+    let mut person_records = Vec::new();
 
     for payload in payload.items {
-        let api_key = payload.token.clone().or(payload.api_key.clone());
+        let api_key = payload
+            .token
+            .clone()
+            .or(payload.api_key.clone())
+            .or_else(|| api_key_from_browser_properties(payload.properties.as_ref()));
 
         let distinct_id = browser_distinct_id(&payload)
             .ok_or_else(|| AppError::InvalidPayload("missing distinct_id".into()))?;
 
         let event = if payload.event == "$identify" {
             let identify_req = browser_identify_request(payload, api_key, distinct_id);
-            if let Some(anon) = identify_req
-                .anon_distinct_id
-                .clone()
-                .or_else(|| {
-                    identify_req
-                        .properties
-                        .as_ref()
-                        .and_then(Value::as_object)
-                        .and_then(|props| props.get("$anon_distinct_id"))
-                        .and_then(Value::as_str)
-                        .map(str::to_string)
-                })
-                .or_else(|| {
-                    identify_req
-                        .extra
-                        .get("$anon_distinct_id")
-                        .and_then(Value::as_str)
-                        .map(str::to_string)
-                })
-            {
+            if let Some(anon) = anon_distinct_id_from_identify(&identify_req) {
                 if anon != identify_req.distinct_id {
                     state
                         .person_store
@@ -684,16 +776,24 @@ async fn browser_capture(
             .map(person_fields)
             .unwrap_or((None, None, None));
 
-        events.push(
-            event
-                .with_team_id(state.posthog_team_id)
-                .with_person(person_id, person_created_at, person_properties)
-                .with_groups(group_slots, group_properties)
-                .with_sent_at(sent_at.clone())
-                .with_enrichment(enrichment),
-        );
+        let event = event
+            .with_team_id(state.posthog_team_id)
+            .with_person(person_id, person_created_at, person_properties)
+            .with_groups(group_slots, group_properties)
+            .with_sent_at(sent_at.clone())
+            .with_enrichment(enrichment);
+        if let Some(snapshot) = snapshot.as_ref() {
+            let operation = if event.event == "$identify" {
+                "identify"
+            } else {
+                "capture"
+            };
+            push_person_record(&mut person_records, snapshot, operation, &event);
+        }
+        events.push(event);
     }
 
+    send_person_records(&state, person_records).await?;
     state.pipeline.send(events).await?;
     Ok(Json(PostHogResponse::success()))
 }
@@ -707,26 +807,10 @@ async fn identify(
     let sent_at = payload.sent_at.clone();
     let enrichment = enrichment.properties();
     let mut events = Vec::new();
+    let mut person_records = Vec::new();
 
     for item in payload.items {
-        if let Some(anon) = item
-            .anon_distinct_id
-            .clone()
-            .or_else(|| {
-                item.properties
-                    .as_ref()
-                    .and_then(Value::as_object)
-                    .and_then(|props| props.get("$anon_distinct_id"))
-                    .and_then(Value::as_str)
-                    .map(|value| value.to_string())
-            })
-            .or_else(|| {
-                item.extra
-                    .get("$anon_distinct_id")
-                    .and_then(Value::as_str)
-                    .map(|value| value.to_string())
-            })
-        {
+        if let Some(anon) = anon_distinct_id_from_identify(&item) {
             if anon != item.distinct_id {
                 state
                     .person_store
@@ -756,16 +840,17 @@ async fn identify(
         };
 
         let (person_id, person_created_at, person_properties) = person_fields(&snapshot);
-        events.push(
-            PipelineEvent::from_identify(item)
-                .with_team_id(state.posthog_team_id)
-                .with_person(person_id, person_created_at, person_properties)
-                .with_groups(group_slots, group_properties)
-                .with_sent_at(sent_at.clone())
-                .with_enrichment(enrichment),
-        );
+        let event = PipelineEvent::from_identify(item)
+            .with_team_id(state.posthog_team_id)
+            .with_person(person_id, person_created_at, person_properties)
+            .with_groups(group_slots, group_properties)
+            .with_sent_at(sent_at.clone())
+            .with_enrichment(enrichment);
+        push_person_record(&mut person_records, &snapshot, "identify", &event);
+        events.push(event);
     }
 
+    send_person_records(&state, person_records).await?;
     state.pipeline.send(events).await?;
     Ok(Json(PostHogResponse::success()))
 }
@@ -782,8 +867,10 @@ async fn batch(
     let items = convert_batch(payload.batch, shared_api_key).map_err(AppError::InvalidPayload)?;
 
     let mut events = Vec::new();
+    let mut person_records = Vec::new();
 
     for item in items {
+        let operation = item.kind.person_operation();
         if let Some(alias) = item.alias {
             let snapshot = state.person_store.apply_alias(alias).await?;
             let (person_id, person_created_at, person_properties) = person_fields(&snapshot);
@@ -794,6 +881,7 @@ async fn batch(
                 .with_groups([None, None, None, None, None], None)
                 .with_sent_at(sent_at.clone())
                 .with_enrichment(enrichment);
+            push_person_record(&mut person_records, &snapshot, operation, &event);
             events.push(event);
             continue;
         }
@@ -871,9 +959,11 @@ async fn batch(
             .with_groups(group_slots, group_properties)
             .with_sent_at(sent_at.clone())
             .with_enrichment(enrichment);
+        push_person_record(&mut person_records, &snapshot, operation, &event);
         events.push(event);
     }
 
+    send_person_records(&state, person_records).await?;
     state.pipeline.send(events).await?;
     Ok(Json(PostHogResponse::success()))
 }
@@ -918,6 +1008,7 @@ async fn alias(
     let sent_at = payload.sent_at.clone();
     let enrichment = enrichment.properties();
     let mut events = Vec::new();
+    let mut person_records = Vec::new();
 
     for item in payload.items {
         let snapshot = state
@@ -925,16 +1016,17 @@ async fn alias(
             .apply_alias(alias_from_request(&item))
             .await?;
         let (person_id, person_created_at, person_properties) = person_fields(&snapshot);
-        events.push(
-            PipelineEvent::from_alias(item)
-                .with_team_id(state.posthog_team_id)
-                .with_person(person_id, person_created_at, person_properties)
-                .with_groups([None, None, None, None, None], None)
-                .with_sent_at(sent_at.clone())
-                .with_enrichment(enrichment),
-        );
+        let event = PipelineEvent::from_alias(item)
+            .with_team_id(state.posthog_team_id)
+            .with_person(person_id, person_created_at, person_properties)
+            .with_groups([None, None, None, None, None], None)
+            .with_sent_at(sent_at.clone())
+            .with_enrichment(enrichment);
+        push_person_record(&mut person_records, &snapshot, "alias", &event);
+        events.push(event);
     }
 
+    send_person_records(&state, person_records).await?;
     state.pipeline.send(events).await?;
     Ok(Json(PostHogResponse::success()))
 }
@@ -948,6 +1040,7 @@ async fn engage(
     let sent_at = payload.sent_at.clone();
     let enrichment = enrichment.properties();
     let mut events = Vec::new();
+    let mut person_records = Vec::new();
 
     for item in payload.items {
         let update = update_from_engage(&item);
@@ -996,16 +1089,17 @@ async fn engage(
         };
 
         let (person_id, person_created_at, person_properties) = person_fields(&snapshot);
-        events.push(
-            PipelineEvent::from_engage(item)
-                .with_team_id(state.posthog_team_id)
-                .with_person(person_id, person_created_at, person_properties)
-                .with_groups(group_slots, group_properties)
-                .with_sent_at(sent_at.clone())
-                .with_enrichment(enrichment),
-        );
+        let event = PipelineEvent::from_engage(item)
+            .with_team_id(state.posthog_team_id)
+            .with_person(person_id, person_created_at, person_properties)
+            .with_groups(group_slots, group_properties)
+            .with_sent_at(sent_at.clone())
+            .with_enrichment(enrichment);
+        push_person_record(&mut person_records, &snapshot, "engage", &event);
+        events.push(event);
     }
 
+    send_person_records(&state, person_records).await?;
     state.pipeline.send(events).await?;
     Ok(Json(PostHogResponse::success()))
 }
@@ -1181,6 +1275,13 @@ async fn session_recording(
         .with_sent_at(sent_at)
         .with_enrichment(enrichment.properties());
 
+    send_person_records(
+        &state,
+        PersonPipelineRecord::from_snapshot(&snapshot, "session_recording", &event)
+            .into_iter()
+            .collect(),
+    )
+    .await?;
     state.pipeline.send(vec![event]).await?;
     Ok(Json(PostHogResponse::success()))
 }
@@ -1381,6 +1482,32 @@ fn person_fields(
         ),
         None => (None, None, None),
     }
+}
+
+fn push_person_record(
+    records: &mut Vec<PersonPipelineRecord>,
+    snapshot: &persons::PersonSnapshot,
+    operation: &str,
+    event: &PipelineEvent,
+) {
+    if let Some(record) = PersonPipelineRecord::from_snapshot(snapshot, operation, event) {
+        records.push(record);
+    }
+}
+
+async fn send_person_records(
+    state: &AppState,
+    records: Vec<PersonPipelineRecord>,
+) -> Result<(), AppError> {
+    if records.is_empty() {
+        return Ok(());
+    }
+
+    if let Some(pipeline) = state.persons_pipeline.as_ref() {
+        pipeline.send_records(records).await?;
+    }
+
+    Ok(())
 }
 
 fn extract_groups(properties: &Option<Value>) -> Option<serde_json::Map<String, Value>> {
@@ -1621,6 +1748,18 @@ enum BatchItemKind {
     GroupIdentify,
 }
 
+impl BatchItemKind {
+    fn person_operation(&self) -> &'static str {
+        match self {
+            BatchItemKind::Capture => "capture",
+            BatchItemKind::Identify => "identify",
+            BatchItemKind::Alias => "alias",
+            BatchItemKind::Engage => "engage",
+            BatchItemKind::GroupIdentify => "group_identify",
+        }
+    }
+}
+
 struct BatchItem {
     #[allow(dead_code)]
     kind: BatchItemKind,
@@ -1771,7 +1910,7 @@ fn convert_batch_item(
             .map(|request| {
                 let update = update_from_identify(&request);
                 let groups = extract_groups(&request.properties);
-                let anon_distinct_id = request.anon_distinct_id.clone();
+                let anon_distinct_id = anon_distinct_id_from_identify(&request);
                 BatchItem {
                     kind: BatchItemKind::Identify,
                     event: PipelineEvent::from_identify(request),
@@ -1876,4 +2015,45 @@ fn convert_batch_item(
             }
         })
         .map_err(|err| format!("invalid capture event: {err}"))
+}
+
+fn api_key_from_browser_properties(properties: Option<&Value>) -> Option<String> {
+    properties.and_then(|props| {
+        props
+            .get("token")
+            .or_else(|| props.get("api_key"))
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(String::from)
+    })
+}
+
+fn anon_distinct_id_from_identify(request: &IdentifyRequest) -> Option<String> {
+    anon_distinct_id_from_parts(
+        request.anon_distinct_id.as_deref(),
+        request.properties.as_ref(),
+        &request.extra,
+    )
+}
+
+fn anon_distinct_id_from_parts(
+    explicit: Option<&str>,
+    properties: Option<&Value>,
+    extra: &std::collections::HashMap<String, Value>,
+) -> Option<String> {
+    explicit
+        .map(str::to_string)
+        .or_else(|| {
+            properties
+                .and_then(Value::as_object)
+                .and_then(|props| props.get("$anon_distinct_id"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .or_else(|| {
+            extra
+                .get("$anon_distinct_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
 }

--- a/src/persons.rs
+++ b/src/persons.rs
@@ -299,18 +299,18 @@ impl PersonStore for MemoryPersonStore {
         }
 
         let mut records = self.records.write().await;
-        let mut primary_record = records
-            .get(&primary_id)
-            .cloned()
+        let primary_existing = records.get(&primary_id).cloned();
+        let secondary_existing = records.get(&secondary_id).cloned();
+        let mut primary_record = primary_existing
+            .clone()
+            .or_else(|| secondary_existing.clone())
             .unwrap_or_else(|| PersonRecord::new(primary_id.clone(), self.team_id, 0));
         if primary_record.id == 0 {
             primary_record.id = self.allocate_id();
         }
         primary_record.ensure_distinct_id(&alias.distinct_id);
 
-        let mut secondary_record = records
-            .get(&secondary_id)
-            .cloned()
+        let mut secondary_record = secondary_existing
             .unwrap_or_else(|| PersonRecord::new(secondary_id.clone(), self.team_id, 0));
         if secondary_record.id == 0 {
             secondary_record.id = self.allocate_id();
@@ -321,10 +321,16 @@ impl PersonStore for MemoryPersonStore {
         records.insert(primary_id.clone(), merged.clone());
 
         let mut redirects = self.redirects.write().await;
-        redirects.insert(secondary_id.clone(), primary_id.clone());
-        redirects.insert(alias.alias.clone(), primary_id.clone());
+        if secondary_id != primary_id {
+            redirects.insert(secondary_id.clone(), primary_id.clone());
+        }
+        if alias.alias != primary_id {
+            redirects.insert(alias.alias.clone(), primary_id.clone());
+        }
         for id in &merged.distinct_ids {
-            redirects.insert(id.clone(), primary_id.clone());
+            if id != &primary_id {
+                redirects.insert(id.clone(), primary_id.clone());
+            }
         }
 
         Ok(PersonSnapshot {
@@ -592,24 +598,9 @@ mod durable {
                 }
                 (Method::Post, "/merge") => {
                     let body: MergePersonRequest = req.json().await?;
-                    let mut primary_record = self
-                        .state
-                        .storage()
-                        .get::<PersonRecord>(RECORD_KEY)
-                        .await?
-                        .unwrap_or_else(|| {
-                            PersonRecord::new(
-                                body.alias.distinct_id.clone(),
-                                body.team_id,
-                                body.primary_allocated_id,
-                            )
-                        });
-                    if primary_record.id == 0 {
-                        primary_record.id = body.primary_allocated_id;
-                    }
-                    primary_record.ensure_distinct_id(&body.alias.distinct_id);
-
-                    let mut secondary_record = body.secondary.unwrap_or_else(|| {
+                    let primary_existing =
+                        self.state.storage().get::<PersonRecord>(RECORD_KEY).await?;
+                    let mut secondary_record = body.secondary.clone().unwrap_or_else(|| {
                         PersonRecord::new(
                             body.alias.alias.clone(),
                             body.team_id,
@@ -620,6 +611,19 @@ mod durable {
                         secondary_record.id = body.secondary_allocated_id;
                     }
                     secondary_record.ensure_distinct_id(&body.alias.alias);
+
+                    let mut primary_record =
+                        primary_existing.or(body.secondary).unwrap_or_else(|| {
+                            PersonRecord::new(
+                                body.alias.distinct_id.clone(),
+                                body.team_id,
+                                body.primary_allocated_id,
+                            )
+                        });
+                    if primary_record.id == 0 {
+                        primary_record.id = body.primary_allocated_id;
+                    }
+                    primary_record.ensure_distinct_id(&body.alias.distinct_id);
 
                     let merged = PersonRecord::merge(&primary_record, &secondary_record);
                     self.state.storage().put(RECORD_KEY, &merged).await?;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -22,6 +22,7 @@ use crate::models::{
     hash_map_is_empty, AliasRequest, CaptureRequest, EngageRequest, GroupIdentifyRequest,
     IdentifyRequest,
 };
+use crate::persons::PersonSnapshot;
 
 #[derive(Clone)]
 pub struct PipelineClient {
@@ -56,9 +57,17 @@ impl PipelineClient {
 
     #[instrument(skip(self, events), fields(event_count = events.len()))]
     pub async fn send(&self, events: Vec<PipelineEvent>) -> Result<(), PipelineError> {
+        self.send_records(events).await
+    }
+
+    #[instrument(skip(self, records), fields(record_count = records.len()))]
+    pub async fn send_records<T>(&self, records: Vec<T>) -> Result<(), PipelineError>
+    where
+        T: Serialize,
+    {
         #[cfg(not(target_arch = "wasm32"))]
         {
-            let mut request = self.client.post(self.endpoint.clone()).json(&events);
+            let mut request = self.client.post(self.endpoint.clone()).json(&records);
 
             if let Some(token) = &self.auth_token {
                 request = request.bearer_auth(token);
@@ -85,7 +94,7 @@ impl PipelineClient {
 
         #[cfg(target_arch = "wasm32")]
         {
-            let body = serde_json::to_string(&events).map_err(PipelineError::Serialize)?;
+            let body = serde_json::to_string(&records).map_err(PipelineError::Serialize)?;
 
             let headers = Headers::new();
             headers
@@ -139,6 +148,63 @@ impl PipelineClient {
 
             Ok(())
         }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct PersonPipelineRecord {
+    pub uuid: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<i64>,
+    pub source: &'static str,
+    pub operation: String,
+    pub person_id: String,
+    pub person_int_id: i64,
+    pub canonical_distinct_id: String,
+    pub distinct_ids: Value,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub version: i64,
+    pub properties: Value,
+    pub properties_set_once: Value,
+    pub merged_properties: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+    pub source_event_uuid: String,
+}
+
+impl PersonPipelineRecord {
+    pub fn from_snapshot(
+        snapshot: &PersonSnapshot,
+        operation: impl Into<String>,
+        event: &PipelineEvent,
+    ) -> Option<Self> {
+        let record = snapshot.record.as_ref()?;
+        Some(Self {
+            uuid: Uuid::new_v4().to_string(),
+            team_id: record.team_id,
+            source: "hogflare",
+            operation: operation.into(),
+            person_id: record.uuid.clone(),
+            person_int_id: record.id,
+            canonical_distinct_id: snapshot.canonical_id.clone(),
+            distinct_ids: Value::Array(
+                record
+                    .distinct_ids
+                    .iter()
+                    .cloned()
+                    .map(Value::String)
+                    .collect(),
+            ),
+            created_at: record.created_at,
+            updated_at: Utc::now(),
+            version: record.version,
+            properties: Value::Object(record.properties.clone()),
+            properties_set_once: Value::Object(record.properties_set_once.clone()),
+            merged_properties: record.merged_properties(),
+            api_key: event.api_key.clone(),
+            source_event_uuid: event.uuid.clone(),
+        })
     }
 }
 

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -75,6 +75,26 @@ pub async fn spawn_app_with_options(
     .await
 }
 
+pub async fn spawn_app_with_options_and_debug(
+    pipeline_endpoint: Url,
+    decide_api_token: Option<String>,
+    session_recording_endpoint: Option<String>,
+    signing_secret: Option<String>,
+    feature_flags: Option<hogflare::feature_flags::FeatureFlagStore>,
+    person_debug_token: Option<String>,
+) -> Result<(SocketAddr, JoinHandle<()>), Box<dyn std::error::Error>> {
+    spawn_app_with_runtime_options(
+        pipeline_endpoint,
+        decide_api_token,
+        session_recording_endpoint,
+        signing_secret,
+        person_debug_token,
+        feature_flags,
+        hogflare::groups::GroupTypeMap::default(),
+    )
+    .await
+}
+
 pub async fn spawn_app_with_runtime_options(
     pipeline_endpoint: Url,
     decide_api_token: Option<String>,
@@ -84,7 +104,55 @@ pub async fn spawn_app_with_runtime_options(
     feature_flags: Option<hogflare::feature_flags::FeatureFlagStore>,
     group_type_map: hogflare::groups::GroupTypeMap,
 ) -> Result<(SocketAddr, JoinHandle<()>), Box<dyn std::error::Error>> {
+    spawn_app_with_runtime_options_and_person_pipeline(
+        pipeline_endpoint,
+        None,
+        decide_api_token,
+        session_recording_endpoint,
+        signing_secret,
+        person_debug_token,
+        feature_flags,
+        group_type_map,
+    )
+    .await
+}
+
+pub async fn spawn_app_with_options_debug_and_person_pipeline(
+    pipeline_endpoint: Url,
+    persons_pipeline_endpoint: Option<Url>,
+    decide_api_token: Option<String>,
+    session_recording_endpoint: Option<String>,
+    signing_secret: Option<String>,
+    feature_flags: Option<hogflare::feature_flags::FeatureFlagStore>,
+    person_debug_token: Option<String>,
+) -> Result<(SocketAddr, JoinHandle<()>), Box<dyn std::error::Error>> {
+    spawn_app_with_runtime_options_and_person_pipeline(
+        pipeline_endpoint,
+        persons_pipeline_endpoint,
+        decide_api_token,
+        session_recording_endpoint,
+        signing_secret,
+        person_debug_token,
+        feature_flags,
+        hogflare::groups::GroupTypeMap::default(),
+    )
+    .await
+}
+
+pub async fn spawn_app_with_runtime_options_and_person_pipeline(
+    pipeline_endpoint: Url,
+    persons_pipeline_endpoint: Option<Url>,
+    decide_api_token: Option<String>,
+    session_recording_endpoint: Option<String>,
+    signing_secret: Option<String>,
+    person_debug_token: Option<String>,
+    feature_flags: Option<hogflare::feature_flags::FeatureFlagStore>,
+    group_type_map: hogflare::groups::GroupTypeMap,
+) -> Result<(SocketAddr, JoinHandle<()>), Box<dyn std::error::Error>> {
     let pipeline_client = PipelineClient::new(pipeline_endpoint, None, Duration::from_secs(5))?;
+    let persons_pipeline_client = persons_pipeline_endpoint
+        .map(|endpoint| PipelineClient::new(endpoint, None, Duration::from_secs(5)).map(Arc::new))
+        .transpose()?;
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let address = listener.local_addr()?;
@@ -92,9 +160,10 @@ pub async fn spawn_app_with_runtime_options(
     let server_handle = tokio::spawn({
         let pipeline = Arc::new(pipeline_client);
         async move {
-            if let Err(err) = hogflare::serve_with_options(
+            if let Err(err) = hogflare::serve_with_person_pipeline(
                 listener,
                 pipeline,
+                persons_pipeline_client,
                 None,
                 Arc::new(hogflare::groups::MemoryGroupStore::new()),
                 group_type_map,

--- a/tests/js_client/posthog_identify_transition.js
+++ b/tests/js_client/posthog_identify_transition.js
@@ -1,0 +1,47 @@
+import { setupPosthog, waitForFlush } from './setup.js';
+
+async function main() {
+  const identifiedId = process.env.HOGFLARE_IDENTIFIED_ID || 'js-identified-transition-user';
+  const { posthog } = await setupPosthog();
+
+  posthog.capture('js-anon-pageview', {
+    client: 'posthog-js',
+    phase: 'anonymous',
+    $set: {
+      initial_referrer: 'adwords',
+      anon_trait: 'curious',
+    },
+    $set_once: {
+      first_seen_source: 'landing-page',
+    },
+  });
+
+  await waitForFlush();
+
+  posthog.identify(
+    identifiedId,
+    {
+      email: 'js-transition@example.com',
+      plan: 'pro',
+    },
+    {
+      signup_source: 'product',
+    },
+  );
+
+  await waitForFlush();
+
+  posthog.capture('js-identified-action', {
+    client: 'posthog-js',
+    phase: 'identified',
+    button: 'checkout',
+  });
+
+  await waitForFlush();
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/js_client/setup.js
+++ b/tests/js_client/setup.js
@@ -50,6 +50,7 @@ export async function setupPosthog(options = {}) {
   return { posthog, apiHost, apiKey, distinctId };
 }
 
-export function waitForFlush(ms = 500) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+export function waitForFlush(ms) {
+  const delay = ms ?? Number(process.env.HOGFLARE_FLUSH_WAIT_MS || 500);
+  return new Promise((resolve) => setTimeout(resolve, delay));
 }

--- a/tests/persons_do.rs
+++ b/tests/persons_do.rs
@@ -103,6 +103,76 @@ async fn durable_object_person_updates_apply() -> Result<(), Box<dyn std::error:
     let alias_snapshot = fetch_person(&client, &base_url, debug_token, "anon-1").await?;
     assert_eq!(alias_snapshot.canonical_id, "person-1");
 
+    // anon capture followed by identify with $anon_distinct_id should keep the anon person id
+    client
+        .post(format!("{base_url}/capture"))
+        .json(&json!({
+            "event": "anon-start",
+            "distinct_id": "anon-existing",
+            "properties": {
+                "$set": { "initial_referrer": "adwords" },
+                "$set_once": { "first_seen_source": "landing" }
+            }
+        }))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let anon_snapshot = fetch_person(&client, &base_url, debug_token, "anon-existing").await?;
+    assert_eq!(anon_snapshot.canonical_id, "anon-existing");
+    let anon_record = anon_snapshot.record.expect("expected anon person record");
+    let anon_uuid = anon_record["uuid"]
+        .as_str()
+        .expect("anon record should have uuid")
+        .to_string();
+    let anon_id = anon_record["id"].clone();
+
+    client
+        .post(format!("{base_url}/identify"))
+        .json(&json!({
+            "distinct_id": "identified-existing",
+            "properties": {
+                "$anon_distinct_id": "anon-existing",
+                "$set": {
+                    "email": "identified@example.com",
+                    "plan": "pro"
+                },
+                "$set_once": {
+                    "signup_source": "product"
+                }
+            }
+        }))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let merged_from_anon = fetch_person(&client, &base_url, debug_token, "anon-existing").await?;
+    assert_eq!(merged_from_anon.canonical_id, "identified-existing");
+    let merged_record = merged_from_anon
+        .record
+        .expect("expected merged person record");
+    assert_eq!(merged_record["uuid"], anon_uuid);
+    assert_eq!(merged_record["id"], anon_id);
+    assert_eq!(
+        merged_record["properties"]["email"],
+        "identified@example.com"
+    );
+    assert_eq!(merged_record["properties"]["plan"], "pro");
+    assert_eq!(merged_record["properties"]["initial_referrer"], "adwords");
+    assert_eq!(
+        merged_record["properties_set_once"]["first_seen_source"],
+        "landing"
+    );
+    assert_eq!(
+        merged_record["properties_set_once"]["signup_source"],
+        "product"
+    );
+    let distinct_ids = merged_record["distinct_ids"]
+        .as_array()
+        .expect("merged record should include distinct ids");
+    assert!(distinct_ids.contains(&Value::String("anon-existing".to_string())));
+    assert!(distinct_ids.contains(&Value::String("identified-existing".to_string())));
+
     shutdown_wrangler(&mut wrangler).await;
     cleanup_wrangler(&mut wrangler).await;
     cleanup_pipeline(pipeline_handle).await;
@@ -198,6 +268,8 @@ fn spawn_wrangler_dev(
         .arg("127.0.0.1")
         .arg("--port")
         .arg(port.to_string())
+        .arg("--persist-to")
+        .arg(log_dir.join("wrangler-state"))
         .arg("--log-level")
         .arg("error")
         .env("WRANGLER_SEND_METRICS", "false")

--- a/tests/posthog_endpoints.rs
+++ b/tests/posthog_endpoints.rs
@@ -4,8 +4,9 @@ mod helpers;
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
 use chrono::Utc;
 use helpers::{
-    cleanup, spawn_app_with_options, spawn_app_with_runtime_options, spawn_pipeline_stub,
-    wait_for_events,
+    cleanup, spawn_app_with_options, spawn_app_with_options_and_debug,
+    spawn_app_with_options_debug_and_person_pipeline, spawn_app_with_runtime_options,
+    spawn_pipeline_stub, wait_for_events,
 };
 use hmac::{Hmac, Mac};
 use hogflare::{feature_flags::FeatureFlagStore, groups::GroupTypeMap};
@@ -656,4 +657,347 @@ async fn posthog_compatibility_endpoints_forward_events() -> Result<(), Box<dyn 
 
     cleanup(server_handle, pipeline_handle).await;
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn anonymous_identify_transition_enriches_events_and_person(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let debug_token = "debug-transition-token";
+    let (pipeline_endpoint, mut pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
+    let (address, server_handle) = spawn_app_with_options_and_debug(
+        pipeline_endpoint,
+        None,
+        None,
+        None,
+        None,
+        Some(debug_token.to_string()),
+    )
+    .await?;
+    let base_url = format!("http://{}", address);
+    let client = Client::builder().timeout(Duration::from_secs(5)).build()?;
+
+    let anon_capture = json!({
+        "event": "anon-pageview",
+        "distinct_id": "anon-transition-user",
+        "api_key": "phc_people_transition",
+        "properties": {
+            "$set": { "initial_referrer": "adwords", "anon_trait": "curious" },
+            "$set_once": { "first_seen_source": "landing-page" },
+            "page": "/landing"
+        }
+    });
+
+    client
+        .post(format!("{}/capture", base_url))
+        .json(&anon_capture)
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let anon_events = wait_for_events(&mut pipeline_rx).await?;
+    let anon_event = anon_events
+        .first()
+        .expect("expected anonymous capture event");
+    assert_eq!(anon_event["event"], "anon-pageview");
+    assert_eq!(anon_event["distinct_id"], "anon-transition-user");
+    assert_eq!(anon_event["api_key"], "phc_people_transition");
+    let anon_person_id = anon_event["person_id"]
+        .as_str()
+        .expect("anonymous event should include person_id")
+        .to_string();
+    assert!(
+        anon_event["person_created_at"].as_str().is_some(),
+        "anonymous event should include person_created_at"
+    );
+    assert_eq!(
+        anon_event["person_properties"]["initial_referrer"],
+        "adwords"
+    );
+    assert_eq!(
+        anon_event["person_properties"]["first_seen_source"],
+        "landing-page"
+    );
+
+    let identify_payload = json!({
+        "distinct_id": "identified-transition-user",
+        "api_key": "phc_people_transition",
+        "properties": {
+            "$anon_distinct_id": "anon-transition-user",
+            "$set": {
+                "email": "transition@example.com",
+                "plan": "pro"
+            },
+            "$set_once": {
+                "signup_source": "product"
+            }
+        }
+    });
+
+    client
+        .post(format!("{}/identify", base_url))
+        .json(&identify_payload)
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let identify_events = wait_for_events(&mut pipeline_rx).await?;
+    let identify_event = identify_events.first().expect("expected identify event");
+    assert_eq!(identify_event["event"], "$identify");
+    assert_eq!(identify_event["distinct_id"], "identified-transition-user");
+    assert_eq!(identify_event["person_id"], anon_person_id);
+    assert_eq!(
+        identify_event["person_properties"]["email"],
+        "transition@example.com"
+    );
+    assert_eq!(identify_event["person_properties"]["plan"], "pro");
+    assert_eq!(
+        identify_event["person_properties"]["initial_referrer"],
+        "adwords"
+    );
+    assert_eq!(
+        identify_event["person_properties"]["first_seen_source"],
+        "landing-page"
+    );
+    assert_eq!(
+        identify_event["person_properties"]["signup_source"],
+        "product"
+    );
+
+    client
+        .post(format!("{}/capture", base_url))
+        .json(&json!({
+            "event": "identified-action",
+            "distinct_id": "identified-transition-user",
+            "api_key": "phc_people_transition",
+            "properties": { "button": "checkout" }
+        }))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let identified_events = wait_for_events(&mut pipeline_rx).await?;
+    let identified_event = identified_events
+        .first()
+        .expect("expected identified capture event");
+    assert_eq!(identified_event["event"], "identified-action");
+    assert_eq!(
+        identified_event["distinct_id"],
+        "identified-transition-user"
+    );
+    assert_eq!(identified_event["person_id"], anon_person_id);
+    assert_eq!(
+        identified_event["person_properties"]["email"],
+        "transition@example.com"
+    );
+    assert_eq!(identified_event["person_properties"]["plan"], "pro");
+    assert_eq!(
+        identified_event["person_properties"]["initial_referrer"],
+        "adwords"
+    );
+
+    let person_response = client
+        .get(format!("{}/__debug/person/anon-transition-user", base_url))
+        .header("x-hogflare-debug-token", debug_token)
+        .send()
+        .await?;
+    assert_eq!(person_response.status(), StatusCode::OK);
+    let person: Value = person_response.json().await?;
+    assert_eq!(person["canonical_id"], "identified-transition-user");
+    assert_eq!(person["record"]["uuid"], anon_person_id);
+    assert_eq!(
+        person["record"]["properties"]["email"],
+        "transition@example.com"
+    );
+    assert_eq!(person["record"]["properties"]["plan"], "pro");
+    assert_eq!(
+        person["record"]["properties"]["initial_referrer"],
+        "adwords"
+    );
+    assert_eq!(
+        person["record"]["properties_set_once"]["first_seen_source"],
+        "landing-page"
+    );
+    assert_eq!(
+        person["record"]["properties_set_once"]["signup_source"],
+        "product"
+    );
+    let distinct_ids = person["record"]["distinct_ids"]
+        .as_array()
+        .expect("person should include distinct_ids");
+    assert!(distinct_ids.contains(&Value::String("anon-transition-user".to_string())));
+    assert!(distinct_ids.contains(&Value::String("identified-transition-user".to_string())));
+
+    cleanup(server_handle, pipeline_handle).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn persons_pipeline_receives_anon_to_identified_snapshots(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let debug_token = "debug-persons-pipeline-token";
+    let (pipeline_endpoint, mut pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
+    let (persons_endpoint, mut persons_rx, persons_handle) = spawn_pipeline_stub().await?;
+    let (address, server_handle) = spawn_app_with_options_debug_and_person_pipeline(
+        pipeline_endpoint,
+        Some(persons_endpoint),
+        None,
+        None,
+        None,
+        None,
+        Some(debug_token.to_string()),
+    )
+    .await?;
+    let base_url = format!("http://{}", address);
+    let client = Client::builder().timeout(Duration::from_secs(5)).build()?;
+
+    client
+        .post(format!("{}/capture", base_url))
+        .json(&json!({
+            "event": "persons-anon-capture",
+            "distinct_id": "persons-anon-id",
+            "api_key": "phc_persons_pipeline",
+            "properties": {
+                "$set": { "initial_referrer": "paid-search" },
+                "$set_once": { "first_seen_source": "landing" },
+                "page": "/start"
+            }
+        }))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let anon_people = wait_for_events(&mut persons_rx).await?;
+    let anon_events = wait_for_events(&mut pipeline_rx).await?;
+    let anon_person = anon_people
+        .first()
+        .expect("expected anonymous person snapshot");
+    let anon_event = anon_events.first().expect("expected anonymous event");
+    assert_eq!(anon_person["operation"], "capture");
+    assert_eq!(anon_person["canonical_distinct_id"], "persons-anon-id");
+    assert_eq!(anon_person["api_key"], "phc_persons_pipeline");
+    assert_eq!(anon_person["source_event_uuid"], anon_event["uuid"]);
+    let person_id = anon_person["person_id"]
+        .as_str()
+        .expect("person snapshot should include person_id")
+        .to_string();
+    assert_eq!(anon_event["person_id"], person_id);
+    assert_json_array_contains(&anon_person["distinct_ids"], "persons-anon-id");
+    assert_eq!(anon_person["properties"]["initial_referrer"], "paid-search");
+    assert_eq!(
+        anon_person["properties_set_once"]["first_seen_source"],
+        "landing"
+    );
+    assert_eq!(
+        anon_person["merged_properties"]["initial_referrer"],
+        "paid-search"
+    );
+    assert_eq!(
+        anon_person["merged_properties"]["first_seen_source"],
+        "landing"
+    );
+
+    client
+        .post(format!("{}/identify", base_url))
+        .json(&json!({
+            "distinct_id": "persons-identified-id",
+            "api_key": "phc_persons_pipeline",
+            "properties": {
+                "$anon_distinct_id": "persons-anon-id",
+                "$set": {
+                    "email": "persons@example.com",
+                    "plan": "pro"
+                },
+                "$set_once": {
+                    "signup_source": "checkout"
+                }
+            }
+        }))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let identified_people = wait_for_events(&mut persons_rx).await?;
+    let identify_events = wait_for_events(&mut pipeline_rx).await?;
+    let identified_person = identified_people
+        .first()
+        .expect("expected identified person snapshot");
+    let identify_event = identify_events.first().expect("expected identify event");
+    assert_eq!(identified_person["operation"], "identify");
+    assert_eq!(
+        identified_person["canonical_distinct_id"],
+        "persons-identified-id"
+    );
+    assert_eq!(identified_person["person_id"], person_id);
+    assert_eq!(
+        identified_person["source_event_uuid"],
+        identify_event["uuid"]
+    );
+    assert_json_array_contains(&identified_person["distinct_ids"], "persons-anon-id");
+    assert_json_array_contains(&identified_person["distinct_ids"], "persons-identified-id");
+    assert_eq!(
+        identified_person["properties"]["email"],
+        "persons@example.com"
+    );
+    assert_eq!(identified_person["properties"]["plan"], "pro");
+    assert_eq!(
+        identified_person["properties"]["initial_referrer"],
+        "paid-search"
+    );
+    assert_eq!(
+        identified_person["properties_set_once"]["first_seen_source"],
+        "landing"
+    );
+    assert_eq!(
+        identified_person["properties_set_once"]["signup_source"],
+        "checkout"
+    );
+    assert_eq!(
+        identified_person["merged_properties"]["signup_source"],
+        "checkout"
+    );
+
+    client
+        .post(format!("{}/capture", base_url))
+        .json(&json!({
+            "event": "persons-identified-capture",
+            "distinct_id": "persons-identified-id",
+            "api_key": "phc_persons_pipeline",
+            "properties": { "button": "pay" }
+        }))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let final_people = wait_for_events(&mut persons_rx).await?;
+    let final_events = wait_for_events(&mut pipeline_rx).await?;
+    let final_person = final_people
+        .first()
+        .expect("expected final person snapshot");
+    let final_event = final_events.first().expect("expected final event");
+    assert_eq!(final_person["operation"], "capture");
+    assert_eq!(final_person["person_id"], person_id);
+    assert_eq!(final_person["source_event_uuid"], final_event["uuid"]);
+    assert_eq!(
+        final_person["canonical_distinct_id"],
+        "persons-identified-id"
+    );
+    assert_eq!(
+        final_person["merged_properties"]["email"],
+        "persons@example.com"
+    );
+    assert_json_array_contains(&final_person["distinct_ids"], "persons-anon-id");
+    assert_json_array_contains(&final_person["distinct_ids"], "persons-identified-id");
+
+    cleanup(server_handle, pipeline_handle).await;
+    persons_handle.abort();
+    let _ = persons_handle.await;
+    Ok(())
+}
+
+fn assert_json_array_contains(value: &Value, expected: &str) {
+    let values = value.as_array().expect("expected JSON array");
+    assert!(
+        values.contains(&Value::String(expected.to_string())),
+        "expected {values:?} to contain {expected:?}"
+    );
 }

--- a/tests/posthog_js.rs
+++ b/tests/posthog_js.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use helpers::{
     cleanup, collect_events_until, spawn_app, spawn_app_with_options,
-    spawn_app_with_runtime_options, spawn_pipeline_stub, start_docker_pipeline,
-    stop_docker_pipeline, wait_for_events, wait_for_pipeline_events,
+    spawn_app_with_options_and_debug, spawn_app_with_runtime_options, spawn_pipeline_stub,
+    start_docker_pipeline, stop_docker_pipeline, wait_for_events, wait_for_pipeline_events,
 };
 use hogflare::groups::GroupTypeMap;
 use reqwest::Client;
@@ -40,6 +40,7 @@ async fn posthog_js_capture_is_forwarded_to_pipeline() -> Result<(), Box<dyn std
     assert_eq!(event["source"], "posthog");
     assert_eq!(event["event"], "js-integration-test");
     assert_eq!(event["distinct_id"], "js-integration-user");
+    assert_eq!(event["api_key"], "phc_test_integration_key");
 
     let properties = event
         .get("properties")
@@ -92,6 +93,7 @@ async fn posthog_js_pipeline_persists_events() -> Result<(), Box<dyn std::error:
 
             assert_eq!(event["distinct_id"], "js-integration-user");
             assert_eq!(event["source"], "posthog");
+            assert_eq!(event["api_key"], "phc_test_integration_key");
             assert_eq!(
                 event["properties"]["framework"].as_str(),
                 Some("integration"),
@@ -138,6 +140,7 @@ async fn posthog_js_identify_is_forwarded_to_pipeline() -> Result<(), Box<dyn st
 
     assert_eq!(event["source"], "posthog");
     assert_eq!(event["distinct_id"], "identified-user-123");
+    assert_eq!(event["api_key"], "phc_test_integration_key");
 
     let person_props = event
         .get("person_properties")
@@ -215,6 +218,141 @@ async fn posthog_js_identify_aliases_anonymous_id_with_sdk_payload(
     assert_eq!(
         snapshot["record"]["properties"]["email"],
         "sdk-identify@example.com"
+    );
+
+    cleanup(server_handle, pipeline_handle).await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn posthog_js_identify_transitions_anonymous_person() -> Result<(), Box<dyn std::error::Error>>
+{
+    let debug_token = "debug-js-transition-token";
+    let anon_id = "js-anon-transition-user";
+    let identified_id = "js-identified-transition-user";
+    let (pipeline_endpoint, mut pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
+    let (address, server_handle) = spawn_app_with_options_and_debug(
+        pipeline_endpoint,
+        None,
+        None,
+        None,
+        None,
+        Some(debug_token.to_string()),
+    )
+    .await?;
+
+    let status = Command::new("bun")
+        .arg("run")
+        .arg("posthog_identify_transition.js")
+        .current_dir("tests/js_client")
+        .env("HOGFLARE_HOST", format!("http://{}", address))
+        .env("HOGFLARE_API_KEY", "phc_test_integration_key")
+        .env("HOGFLARE_DISTINCT_ID", anon_id)
+        .env("HOGFLARE_IDENTIFIED_ID", identified_id)
+        .status()
+        .await?;
+
+    if !status.success() {
+        return Err(format!("posthog transition script exited with status {status:?}").into());
+    }
+
+    let mut all_events: Vec<Value> = Vec::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while all_events.len() < 3 && tokio::time::Instant::now() < deadline {
+        if let Ok(events) = tokio::time::timeout(
+            Duration::from_millis(500),
+            wait_for_events(&mut pipeline_rx),
+        )
+        .await
+        {
+            if let Ok(batch) = events {
+                all_events.extend(batch);
+            }
+        }
+    }
+
+    let find_event = |event_name: &str| -> &Value {
+        all_events
+            .iter()
+            .find(|event| event["event"] == event_name)
+            .unwrap_or_else(|| panic!("missing event {event_name}: {all_events:?}"))
+    };
+
+    let anon_event = find_event("js-anon-pageview");
+    assert_eq!(anon_event["distinct_id"], anon_id);
+    assert_eq!(anon_event["api_key"], "phc_test_integration_key");
+    let person_id = anon_event["person_id"]
+        .as_str()
+        .expect("anonymous SDK event should include person_id");
+    assert_eq!(
+        anon_event["person_properties"]["initial_referrer"],
+        "adwords"
+    );
+    assert_eq!(
+        anon_event["person_properties"]["first_seen_source"],
+        "landing-page"
+    );
+
+    let identify_event = find_event("$identify");
+    assert_eq!(identify_event["distinct_id"], identified_id);
+    assert_eq!(identify_event["api_key"], "phc_test_integration_key");
+    assert_eq!(identify_event["person_id"], person_id);
+    assert_eq!(
+        identify_event["person_properties"]["email"],
+        "js-transition@example.com"
+    );
+    assert_eq!(identify_event["person_properties"]["plan"], "pro");
+    assert_eq!(
+        identify_event["person_properties"]["initial_referrer"],
+        "adwords"
+    );
+    assert_eq!(
+        identify_event["person_properties"]["first_seen_source"],
+        "landing-page"
+    );
+    assert_eq!(
+        identify_event["person_properties"]["signup_source"],
+        "product"
+    );
+
+    let identified_event = find_event("js-identified-action");
+    assert_eq!(identified_event["distinct_id"], identified_id);
+    assert_eq!(identified_event["api_key"], "phc_test_integration_key");
+    assert_eq!(identified_event["person_id"], person_id);
+    assert_eq!(
+        identified_event["person_properties"]["email"],
+        "js-transition@example.com"
+    );
+    assert_eq!(
+        identified_event["person_properties"]["initial_referrer"],
+        "adwords"
+    );
+
+    let client = Client::builder().timeout(Duration::from_secs(2)).build()?;
+    let person_response = client
+        .get(format!("http://{}/__debug/person/{}", address, anon_id))
+        .header("x-hogflare-debug-token", debug_token)
+        .send()
+        .await?;
+    assert!(person_response.status().is_success());
+    let person: Value = person_response.json().await?;
+    assert_eq!(person["canonical_id"], identified_id);
+    assert_eq!(person["record"]["uuid"], person_id);
+    assert_eq!(
+        person["record"]["properties"]["email"],
+        "js-transition@example.com"
+    );
+    assert_eq!(
+        person["record"]["properties"]["initial_referrer"],
+        "adwords"
+    );
+    assert_eq!(
+        person["record"]["properties_set_once"]["first_seen_source"],
+        "landing-page"
+    );
+    assert_eq!(
+        person["record"]["properties_set_once"]["signup_source"],
+        "product"
     );
 
     cleanup(server_handle, pipeline_handle).await;

--- a/tests/simulation.rs
+++ b/tests/simulation.rs
@@ -1,0 +1,831 @@
+#[path = "helpers/mod.rs"]
+mod helpers;
+
+use std::{
+    collections::{HashMap, HashSet},
+    net::SocketAddr,
+    sync::Arc,
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use helpers::{cleanup, spawn_pipeline_stub};
+use hogflare::{
+    feature_flags::FeatureFlagStore,
+    groups::{GroupError, GroupRecord, GroupSnapshot, GroupStore, GroupTypeMap, GroupUpdate},
+    pipeline::PipelineClient,
+};
+use reqwest::{Client, Url};
+use serde_json::{json, Value};
+use tokio::{net::TcpListener, sync::Mutex, task::JoinHandle};
+
+const API_KEY: &str = "phc_simulation";
+const DEBUG_TOKEN: &str = "debug-simulation-token";
+const USER_COUNT: usize = 100;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UserPath {
+    AnonOnly,
+    DirectIdentified,
+    AnonToIdentified,
+    Batched,
+}
+
+#[derive(Debug, Clone)]
+struct SimUser {
+    index: usize,
+    path: UserPath,
+    anon_id: String,
+    identified_id: String,
+    canonical_id: String,
+    plan: &'static str,
+    company: String,
+    enterprise_company: bool,
+}
+
+#[derive(Default)]
+struct MemoryGroupStore {
+    records: Mutex<HashMap<(String, String), GroupRecord>>,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl GroupStore for MemoryGroupStore {
+    async fn apply_update(&self, update: GroupUpdate) -> Result<GroupSnapshot, GroupError> {
+        let mut records = self.records.lock().await;
+        let key = (update.group_type.clone(), update.group_key.clone());
+        let record = records
+            .entry(key)
+            .or_insert_with(|| GroupRecord::new(update.group_type.clone(), update.group_key));
+        record.apply_update(&update.properties);
+        Ok(GroupSnapshot {
+            record: Some(record.clone()),
+        })
+    }
+
+    async fn get_snapshot(
+        &self,
+        group_type: &str,
+        group_key: &str,
+    ) -> Result<GroupSnapshot, GroupError> {
+        let records = self.records.lock().await;
+        Ok(GroupSnapshot {
+            record: records
+                .get(&(group_type.to_string(), group_key.to_string()))
+                .cloned(),
+        })
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn simulates_mixed_people_flags_groups_and_sessions() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (pipeline_endpoint, pipeline_rx, pipeline_handle) = spawn_pipeline_stub().await?;
+    let collected_events = collect_pipeline_events(pipeline_rx);
+    let flags = simulation_flags()?;
+    let (address, server_handle) = spawn_simulation_app(pipeline_endpoint, flags).await?;
+    let base_url = format!("http://{address}");
+    let client = Client::builder().timeout(Duration::from_secs(5)).build()?;
+    let users = simulation_users();
+
+    seed_companies(&client, &base_url).await?;
+
+    for user in &users {
+        run_user_path(&client, &base_url, user).await?;
+
+        if user.index % 10 == 0 {
+            engage_user(&client, &base_url, user).await?;
+        }
+
+        if user.index % 20 == 0 {
+            alias_user(&client, &base_url, user).await?;
+        }
+
+        if user.index % 25 == 0 {
+            send_session_recording(&client, &base_url, user).await?;
+        }
+
+        assert_feature_flags(&client, &base_url, user).await?;
+    }
+
+    assert_flag_endpoint_config(&client, &base_url, &users[0]).await?;
+    assert_disable_flags(&client, &base_url, &users[0]).await?;
+
+    let expected_events = 5 + 225 + 10 + 5 + 4;
+    let events = wait_for_collected_events(&collected_events, expected_events).await?;
+    assert_eq!(events.len(), expected_events);
+
+    assert_eq!(count_event(&events, "$groupidentify"), 5);
+    assert_eq!(count_event(&events, "sim-anon-capture"), 50);
+    assert_eq!(count_event(&events, "sim-identified-capture"), 25);
+    assert_eq!(count_event(&events, "sim-post-identify-capture"), 25);
+    assert_eq!(count_event(&events, "sim-batch-capture"), 25);
+    assert_eq!(count_event(&events, "$identify"), 75);
+    assert_eq!(count_event(&events, "$create_alias"), 30);
+    assert_eq!(count_event(&events, "$engage"), 10);
+    assert_eq!(count_event(&events, "$snapshot"), 4);
+
+    assert_user_event_shape(&events, &users)?;
+    assert_debug_people(&client, &base_url, &events, &users).await?;
+
+    cleanup(server_handle, pipeline_handle).await;
+    Ok(())
+}
+
+fn simulation_flags() -> Result<FeatureFlagStore, serde_json::Error> {
+    FeatureFlagStore::from_json(
+        &json!({
+            "flags": [
+                {
+                    "key": "pro-plan",
+                    "type": "boolean",
+                    "active": true,
+                    "rollout_percentage": 100,
+                    "conditions": [
+                        {
+                            "properties": [
+                                { "key": "plan", "value": "pro", "type": "person" }
+                            ]
+                        }
+                    ],
+                    "payload": { "tier": "pro" }
+                },
+                {
+                    "key": "enterprise-company",
+                    "type": "boolean",
+                    "active": true,
+                    "rollout_percentage": 100,
+                    "group_type": "company",
+                    "conditions": [
+                        {
+                            "properties": [
+                                {
+                                    "key": "tier",
+                                    "value": "enterprise",
+                                    "type": "group",
+                                    "group_type": "company"
+                                }
+                            ]
+                        }
+                    ],
+                    "payload": { "scope": "company" }
+                },
+                {
+                    "key": "checkout-copy",
+                    "type": "multivariate",
+                    "active": true,
+                    "rollout_percentage": 100,
+                    "variants": [
+                        {
+                            "key": "control",
+                            "rollout_percentage": 50,
+                            "payload": { "headline": "control" }
+                        },
+                        {
+                            "key": "variant",
+                            "rollout_percentage": 50,
+                            "payload": { "headline": "variant" }
+                        }
+                    ]
+                },
+                {
+                    "key": "prod-only",
+                    "active": true,
+                    "rollout_percentage": 100,
+                    "evaluation_environments": ["prod"],
+                    "payload": { "env": "prod" }
+                }
+            ]
+        })
+        .to_string(),
+    )
+}
+
+fn simulation_users() -> Vec<SimUser> {
+    (0..USER_COUNT)
+        .map(|index| {
+            let path = match index % 4 {
+                0 => UserPath::AnonOnly,
+                1 => UserPath::DirectIdentified,
+                2 => UserPath::AnonToIdentified,
+                _ => UserPath::Batched,
+            };
+            let company_index = index % 5;
+            let company = format!("company-{company_index}");
+            let plan = if index % 3 == 0 { "pro" } else { "free" };
+            let anon_id = format!("sim-anon-{index:03}");
+            let identified_id = format!("sim-user-{index:03}");
+            let canonical_id = match path {
+                UserPath::AnonOnly => anon_id.clone(),
+                UserPath::DirectIdentified | UserPath::AnonToIdentified | UserPath::Batched => {
+                    identified_id.clone()
+                }
+            };
+
+            SimUser {
+                index,
+                path,
+                anon_id,
+                identified_id,
+                canonical_id,
+                plan,
+                company,
+                enterprise_company: company_index % 2 == 0,
+            }
+        })
+        .collect()
+}
+
+async fn spawn_simulation_app(
+    pipeline_endpoint: Url,
+    feature_flags: FeatureFlagStore,
+) -> Result<(SocketAddr, JoinHandle<()>), Box<dyn std::error::Error>> {
+    let pipeline = PipelineClient::new(pipeline_endpoint, None, Duration::from_secs(5))?;
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let group_store: Arc<dyn GroupStore> = Arc::new(MemoryGroupStore::default());
+    let group_type_map = GroupTypeMap::new([
+        Some("company".to_string()),
+        Some("project".to_string()),
+        None,
+        None,
+        None,
+    ]);
+
+    let handle = tokio::spawn(async move {
+        if let Err(err) = hogflare::serve_with_options(
+            listener,
+            Arc::new(pipeline),
+            Some(42),
+            group_store,
+            group_type_map,
+            Some(API_KEY.to_string()),
+            Some("https://session.example.test".to_string()),
+            None,
+            Some(DEBUG_TOKEN.to_string()),
+            Arc::new(feature_flags),
+        )
+        .await
+        {
+            eprintln!("hogflare simulation server terminated: {err}");
+        }
+    });
+
+    Ok((address, handle))
+}
+
+fn collect_pipeline_events(
+    mut pipeline_rx: tokio::sync::mpsc::Receiver<Vec<Value>>,
+) -> Arc<Mutex<Vec<Value>>> {
+    let collected = Arc::new(Mutex::new(Vec::new()));
+    let target = Arc::clone(&collected);
+    tokio::spawn(async move {
+        while let Some(batch) = pipeline_rx.recv().await {
+            target.lock().await.extend(batch);
+        }
+    });
+    collected
+}
+
+async fn seed_companies(client: &Client, base_url: &str) -> Result<(), Box<dyn std::error::Error>> {
+    for company_index in 0..5 {
+        let tier = if company_index % 2 == 0 {
+            "enterprise"
+        } else {
+            "startup"
+        };
+        post_ok(
+            client,
+            &format!("{base_url}/groups"),
+            json!({
+                "api_key": API_KEY,
+                "group_type": "company",
+                "group_key": format!("company-{company_index}"),
+                "properties": {
+                    "tier": tier,
+                    "company_index": company_index,
+                    "region": if company_index % 2 == 0 { "us" } else { "eu" }
+                }
+            }),
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn run_user_path(
+    client: &Client,
+    base_url: &str,
+    user: &SimUser,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match user.path {
+        UserPath::AnonOnly => {
+            post_ok(
+                client,
+                &format!("{base_url}/capture"),
+                json!({
+                    "api_key": API_KEY,
+                    "event": "sim-anon-capture",
+                    "distinct_id": user.anon_id,
+                    "properties": capture_properties(user, "anon_only")
+                }),
+            )
+            .await?;
+        }
+        UserPath::DirectIdentified => {
+            post_ok(
+                client,
+                &format!("{base_url}/identify"),
+                json!({
+                    "api_key": API_KEY,
+                    "distinct_id": user.identified_id,
+                    "properties": identify_properties(user, "direct_identified")
+                }),
+            )
+            .await?;
+            post_ok(
+                client,
+                &format!("{base_url}/capture"),
+                json!({
+                    "api_key": API_KEY,
+                    "event": "sim-identified-capture",
+                    "distinct_id": user.identified_id,
+                    "properties": capture_properties(user, "direct_identified")
+                }),
+            )
+            .await?;
+        }
+        UserPath::AnonToIdentified => {
+            post_ok(
+                client,
+                &format!("{base_url}/capture"),
+                json!({
+                    "api_key": API_KEY,
+                    "event": "sim-anon-capture",
+                    "distinct_id": user.anon_id,
+                    "properties": capture_properties(user, "anon_to_identified")
+                }),
+            )
+            .await?;
+            post_ok(
+                client,
+                &format!("{base_url}/identify"),
+                json!({
+                    "api_key": API_KEY,
+                    "distinct_id": user.identified_id,
+                    "$anon_distinct_id": user.anon_id,
+                    "properties": {
+                        "$set": identify_properties(user, "anon_to_identified"),
+                        "$set_once": {
+                            "signup_source": "simulation"
+                        }
+                    }
+                }),
+            )
+            .await?;
+            post_ok(
+                client,
+                &format!("{base_url}/capture"),
+                json!({
+                    "api_key": API_KEY,
+                    "event": "sim-post-identify-capture",
+                    "distinct_id": user.identified_id,
+                    "properties": capture_properties(user, "anon_to_identified")
+                }),
+            )
+            .await?;
+        }
+        UserPath::Batched => {
+            post_ok(
+                client,
+                &format!("{base_url}/batch"),
+                json!({
+                    "api_key": API_KEY,
+                    "batch": [
+                        {
+                            "event": "sim-batch-capture",
+                            "distinct_id": user.identified_id,
+                            "properties": capture_properties(user, "batched")
+                        },
+                        {
+                            "event": "$identify",
+                            "distinct_id": user.identified_id,
+                            "properties": identify_properties(user, "batched")
+                        },
+                        {
+                            "type": "alias",
+                            "distinct_id": user.identified_id,
+                            "alias": format!("sim-batch-alias-{:03}", user.index)
+                        }
+                    ]
+                }),
+            )
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn identify_properties(user: &SimUser, cohort: &str) -> Value {
+    json!({
+        "email": format!("user{:03}@example.com", user.index),
+        "plan": user.plan,
+        "cohort": cohort,
+        "company": user.company
+    })
+}
+
+fn capture_properties(user: &SimUser, cohort: &str) -> Value {
+    json!({
+        "cohort": cohort,
+        "index": user.index,
+        "plan": user.plan,
+        "company": user.company,
+        "$groups": {
+            "company": user.company
+        },
+        "$group_set": {
+            "company": {
+                "last_user_index": user.index
+            }
+        },
+        "$set": {
+            "plan": user.plan,
+            "cohort": cohort,
+            "company": user.company
+        },
+        "$set_once": {
+            "first_seen_source": "simulation"
+        }
+    })
+}
+
+async fn engage_user(
+    client: &Client,
+    base_url: &str,
+    user: &SimUser,
+) -> Result<(), Box<dyn std::error::Error>> {
+    post_ok(
+        client,
+        &format!("{base_url}/engage"),
+        json!({
+            "api_key": API_KEY,
+            "distinct_id": user.canonical_id,
+            "$set": {
+                "last_engaged_index": user.index
+            },
+            "$set_once": {
+                "engaged_source": "simulation"
+            },
+            "$groups": {
+                "company": user.company
+            }
+        }),
+    )
+    .await
+}
+
+async fn alias_user(
+    client: &Client,
+    base_url: &str,
+    user: &SimUser,
+) -> Result<(), Box<dyn std::error::Error>> {
+    post_ok(
+        client,
+        &format!("{base_url}/alias"),
+        json!({
+            "api_key": API_KEY,
+            "distinct_id": user.canonical_id,
+            "alias": format!("sim-extra-alias-{:03}", user.index)
+        }),
+    )
+    .await
+}
+
+async fn send_session_recording(
+    client: &Client,
+    base_url: &str,
+    user: &SimUser,
+) -> Result<(), Box<dyn std::error::Error>> {
+    post_ok(
+        client,
+        &format!("{base_url}/s"),
+        json!({
+            "token": API_KEY,
+            "data": {
+                "metadata": {
+                    "distinct_id": user.canonical_id
+                },
+                "snapshot_data": {
+                    "type": "full_snapshot",
+                    "source": "simulation"
+                }
+            }
+        }),
+    )
+    .await
+}
+
+async fn assert_feature_flags(
+    client: &Client,
+    base_url: &str,
+    user: &SimUser,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let body = post_json(
+        client,
+        &format!("{base_url}/decide?v=2"),
+        json!({
+            "token": API_KEY,
+            "distinct_id": user.canonical_id,
+            "groups": {
+                "company": user.company
+            },
+            "evaluation_environments": ["prod"]
+        }),
+    )
+    .await?;
+    let flags = body["featureFlags"]
+        .as_object()
+        .expect("decide should return featureFlags");
+    let payloads = body["featureFlagPayloads"]
+        .as_object()
+        .expect("decide should return featureFlagPayloads");
+
+    assert_eq!(
+        flags.get("pro-plan"),
+        Some(&Value::Bool(user.plan == "pro"))
+    );
+    assert_eq!(
+        flags.get("enterprise-company"),
+        Some(&Value::Bool(user.enterprise_company))
+    );
+    assert_eq!(flags.get("prod-only"), Some(&Value::Bool(true)));
+
+    let variant = flags
+        .get("checkout-copy")
+        .and_then(Value::as_str)
+        .expect("checkout-copy should return a variant");
+    assert!(matches!(variant, "control" | "variant"));
+    assert!(payloads.get("checkout-copy").is_some());
+
+    if user.plan == "pro" {
+        assert_eq!(payloads["pro-plan"]["tier"], "pro");
+    } else {
+        assert!(payloads.get("pro-plan").is_none());
+    }
+
+    Ok(())
+}
+
+async fn assert_flag_endpoint_config(
+    client: &Client,
+    base_url: &str,
+    user: &SimUser,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let body = post_json(
+        client,
+        &format!("{base_url}/flags?v=2&config=true"),
+        json!({
+            "token": API_KEY,
+            "distinct_id": user.canonical_id,
+            "groups": {
+                "company": user.company
+            },
+            "evaluation_environments": ["prod"]
+        }),
+    )
+    .await?;
+
+    assert!(body["requestId"].as_str().is_some());
+    assert!(body["evaluatedAt"].as_i64().is_some());
+    assert_eq!(
+        body["sessionRecording"]["endpoint"],
+        "https://session.example.test"
+    );
+    assert_eq!(body["supportedCompression"][0], "gzip");
+    assert!(body["flags"]["pro-plan"]["reason"]["code"]
+        .as_str()
+        .is_some());
+
+    let dev_body = post_json(
+        client,
+        &format!("{base_url}/flags?v=2"),
+        json!({
+            "token": API_KEY,
+            "distinct_id": user.canonical_id,
+            "groups": {
+                "company": user.company
+            },
+            "evaluation_environments": ["dev"]
+        }),
+    )
+    .await?;
+    assert!(dev_body["featureFlags"].get("prod-only").is_none());
+
+    Ok(())
+}
+
+async fn assert_disable_flags(
+    client: &Client,
+    base_url: &str,
+    user: &SimUser,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let body = post_json(
+        client,
+        &format!("{base_url}/decide?v=2"),
+        json!({
+            "token": API_KEY,
+            "distinct_id": user.canonical_id,
+            "disable_flags": true
+        }),
+    )
+    .await?;
+    assert!(body["featureFlags"].as_object().unwrap().is_empty());
+    assert!(body["featureFlagPayloads"].as_object().unwrap().is_empty());
+    Ok(())
+}
+
+fn assert_user_event_shape(
+    events: &[Value],
+    users: &[SimUser],
+) -> Result<(), Box<dyn std::error::Error>> {
+    for user in users {
+        let ids = [
+            user.anon_id.as_str(),
+            user.identified_id.as_str(),
+            user.canonical_id.as_str(),
+        ];
+        let user_events: Vec<&Value> = events
+            .iter()
+            .filter(|event| {
+                event
+                    .get("distinct_id")
+                    .and_then(Value::as_str)
+                    .is_some_and(|distinct_id| ids.contains(&distinct_id))
+            })
+            .filter(|event| event["event"] != "$snapshot")
+            .collect();
+
+        assert!(!user_events.is_empty(), "missing events for {user:?}");
+        let person_ids: HashSet<&str> = user_events
+            .iter()
+            .filter_map(|event| event.get("person_id").and_then(Value::as_str))
+            .collect();
+        assert_eq!(person_ids.len(), 1, "split person ids for {user:?}");
+
+        for event in user_events {
+            assert_eq!(event["team_id"], 42);
+            assert_eq!(event["api_key"], API_KEY);
+            assert!(event["person_created_at"].as_str().is_some());
+
+            if event["event"] == "sim-anon-capture"
+                || event["event"] == "sim-identified-capture"
+                || event["event"] == "sim-post-identify-capture"
+                || event["event"] == "sim-batch-capture"
+            {
+                assert_eq!(event["group0"], user.company);
+                assert_eq!(
+                    event["group_properties"]["company"]["tier"]
+                        .as_str()
+                        .is_some(),
+                    true
+                );
+                assert_eq!(event["properties"]["plan"], user.plan);
+                assert_eq!(event["person_properties"]["plan"], user.plan);
+                assert_eq!(
+                    event["person_properties"]["first_seen_source"],
+                    "simulation"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn assert_debug_people(
+    client: &Client,
+    base_url: &str,
+    events: &[Value],
+    users: &[SimUser],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let anon_transition = users
+        .iter()
+        .find(|user| user.path == UserPath::AnonToIdentified)
+        .expect("simulation should include anon-to-identified user");
+    let anon_capture = find_event(events, "sim-anon-capture", &anon_transition.anon_id)
+        .expect("missing anon transition capture");
+    let identified_capture = find_event(
+        events,
+        "sim-post-identify-capture",
+        &anon_transition.identified_id,
+    )
+    .expect("missing identified transition capture");
+    assert_eq!(anon_capture["person_id"], identified_capture["person_id"]);
+
+    let snapshot = debug_person(client, base_url, &anon_transition.anon_id).await?;
+    assert_eq!(snapshot["canonical_id"], anon_transition.identified_id);
+    assert_eq!(snapshot["record"]["uuid"], anon_capture["person_id"]);
+    assert_eq!(
+        snapshot["record"]["properties"]["plan"],
+        anon_transition.plan
+    );
+    assert_eq!(
+        snapshot["record"]["properties_set_once"]["signup_source"],
+        "simulation"
+    );
+
+    let anon_only = users
+        .iter()
+        .find(|user| user.path == UserPath::AnonOnly)
+        .expect("simulation should include anon-only user");
+    let snapshot = debug_person(client, base_url, &anon_only.anon_id).await?;
+    assert_eq!(snapshot["canonical_id"], anon_only.anon_id);
+    assert_eq!(
+        snapshot["record"]["distinct_ids"][0].as_str(),
+        Some(anon_only.anon_id.as_str())
+    );
+
+    Ok(())
+}
+
+fn count_event(events: &[Value], event_name: &str) -> usize {
+    events
+        .iter()
+        .filter(|event| event["event"] == event_name)
+        .count()
+}
+
+fn find_event<'a>(events: &'a [Value], event_name: &str, distinct_id: &str) -> Option<&'a Value> {
+    events
+        .iter()
+        .find(|event| event["event"] == event_name && event["distinct_id"] == distinct_id)
+}
+
+async fn wait_for_collected_events(
+    events: &Arc<Mutex<Vec<Value>>>,
+    expected_count: usize,
+) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    for _ in 0..100 {
+        let snapshot = events.lock().await.clone();
+        if snapshot.len() >= expected_count {
+            return Ok(snapshot);
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    Err(format!(
+        "timed out waiting for {expected_count} events, got {}",
+        events.lock().await.len()
+    )
+    .into())
+}
+
+async fn debug_person(
+    client: &Client,
+    base_url: &str,
+    distinct_id: &str,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let response = client
+        .get(format!("{base_url}/__debug/person/{distinct_id}"))
+        .header("x-hogflare-debug-token", DEBUG_TOKEN)
+        .send()
+        .await?;
+    assert!(
+        response.status().is_success(),
+        "debug person failed: {}",
+        response.status()
+    );
+    Ok(response.json().await?)
+}
+
+async fn post_ok(
+    client: &Client,
+    url: &str,
+    payload: Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let response = client.post(url).json(&payload).send().await?;
+    assert!(
+        response.status().is_success(),
+        "POST {url} failed with {}: {}",
+        response.status(),
+        response.text().await?
+    );
+    Ok(())
+}
+
+async fn post_json(
+    client: &Client,
+    url: &str,
+    payload: Value,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let response = client.post(url).json(&payload).send().await?;
+    assert!(
+        response.status().is_success(),
+        "POST {url} failed with {}: {}",
+        response.status(),
+        response.text().await?
+    );
+    Ok(response.json().await?)
+}

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -4,6 +4,7 @@ compatibility_date = "2025-01-09"
 
 [vars]
 CLOUDFLARE_PIPELINE_ENDPOINT = "https://<stream-id>.ingest.cloudflare.com"
+CLOUDFLARE_PERSONS_PIPELINE_ENDPOINT = "https://<persons-stream-id>.ingest.cloudflare.com"
 CLOUDFLARE_PIPELINE_TIMEOUT_SECS = "10"
 
 [[durable_objects.bindings]]


### PR DESCRIPTION
Adds an optional persons pipeline that writes append-only person snapshots to a separate Iceberg table while keeping event ingestion unchanged. The Worker can now send events and person records to separate Cloudflare Pipelines, with config support for a dedicated persons stream token and fallback to the events token.

Also fixes anonymous-to-identified person merging so the anonymous person UUID/id is preserved, adds local and SDK coverage for identify transitions, adds a 100-user simulation test for people, groups, feature flags, and sessions, and expands Cloudflare setup docs with schema files, verification steps, and cleanup notes.

Validated with `cargo test --all --locked` and `worker-build --release`. I also scanned the staged diff for production hostnames, account IDs, emails, run IDs, and token-looking values before committing; the local production simulation helper was left untracked and is not included.