### PR TITLE
Add Sidemantic product analytics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ regex = "1"
 axum = { version = "0.7", default-features = false, features = ["json", "query", "tokio", "http1"] }
 dotenvy = "0.15"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
-tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "process", "net", "time"] }
+tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "process", "net", "time", "io-util", "sync"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ flowchart TB
     EventsPipeline --> EventsR2["R2 Data Catalog<br/>events table"]
     PersonsPipeline --> PersonsR2["R2 Data Catalog<br/>persons table"]
 
-    ReplayUI["Replay Explorer"] -->|"R2 SQL"| EventsR2
+    WebUI["Hogflare UI"] -->|"R2 SQL"| EventsR2
     Models["Semantic Models<br/>models/*.yml"] --> EventsR2
     Models --> PersonsR2
     Consumers["DuckDB / R2 SQL / BI"] --> Models

--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -1,0 +1,28 @@
+# Product Analytics
+
+Hogflare serves product analytics from `/analytics`. The dashboard uses the repo's Sidemantic `events`, `pageviews`, and `sessions` models through the native Sidemantic/DuckDB Iceberg bridge.
+
+## API Config
+
+Product analytics shares the same R2 Data Catalog warehouse credentials as replay, but uses analytics-specific names when provided:
+
+| Setting | Notes |
+| --- | --- |
+| `HOGFLARE_ANALYTICS_ACCOUNT_ID` | Cloudflare account id for the R2 Data Catalog warehouse. Falls back to `HOGFLARE_REPLAY_ACCOUNT_ID`. |
+| `HOGFLARE_ANALYTICS_BUCKET` | R2 bucket name backing the warehouse. Falls back to `HOGFLARE_REPLAY_BUCKET`. |
+| `HOGFLARE_ANALYTICS_R2_SQL_TOKEN` | R2 SQL/Data Catalog token. Store as a secret. Falls back to `HOGFLARE_REPLAY_R2_SQL_TOKEN`. |
+| `HOGFLARE_ANALYTICS_EVENTS_TABLE` | Iceberg events table. Falls back to `HOGFLARE_REPLAY_EVENTS_TABLE`. |
+| `HOGFLARE_ANALYTICS_PERSONS_TABLE` | Optional Iceberg persons table. Defaults are inferred from the events table. |
+| `HOGFLARE_ANALYTICS_MODEL_DIR` | Optional Sidemantic model directory. Defaults to `models`. |
+| `HOGFLARE_ANALYTICS_SIDEMANTIC_SCRIPT` | Optional override for the native analytics worker script. |
+| `HOGFLARE_ANALYTICS_PREAGG` | Optional Sidemantic pre-aggregation switch. Defaults to enabled. Set to `0` to disable. |
+| `HOGFLARE_ANALYTICS_PREAGG_SCHEMA` | Optional DuckDB schema for Sidemantic rollup tables. Defaults to `sidemantic_preagg`. |
+
+## Routes
+
+- `/` serves the Hogflare app and opens product analytics by default.
+- `/analytics` serves the product analytics view.
+- `/analytics/api/charts` returns overview metrics, a focused trend, and semantic breakdowns including domains, referrers, browser, country, region, and city leaderboards.
+- `/replay` serves the replay feature.
+
+At worker startup, Sidemantic materializes known count-based chart shapes into daily pre-aggregation rollups and automatically routes eligible queries through those tables. `metric`, `dimension`, and `granularity` choose the focused chart. `semantic_filters` carries clickable cross-filter state as a JSON object of semantic dimensions to values. Analytics leaderboards use a fixed top-10 row cap plus an Others row.

--- a/docs/session-replay.md
+++ b/docs/session-replay.md
@@ -2,7 +2,7 @@
 
 ![Hogflare replay explorer](assets/replay-explorer.jpg)
 
-Hogflare stores replay uploads in the same events table as analytics events, then serves a read-only replay explorer from `/replay`. The UI is for product analytics workflows: browse recent sessions, search events, inspect funnel drop-offs, review computed friction signals, and follow a person journey.
+Hogflare stores replay uploads in the same events table as product events, then serves a read-only replay explorer from `/replay`. The replay feature is for browsing recent sessions, searching events, inspecting funnel drop-offs, reviewing computed friction signals, and following a person journey.
 
 ## Ingestion
 
@@ -27,14 +27,16 @@ Replay APIs require:
 
 The token stays server-side in the Worker. The browser only calls Hogflare's replay API.
 
+Product analytics has a separate first-class route and API. See [product analytics](product-analytics.md).
+
 ## Routes
 
 - `/replay` serves the explorer UI.
 - `/replay/api/sessions` lists replay sessions by reading `$snapshot_items` and legacy `$snapshot` rows from Iceberg through R2 SQL.
-- `/replay/api/events` searches analytics events while excluding replay recording rows.
+- `/replay/api/events` searches product events while excluding replay recording rows.
 - `/replay/api/funnels` classifies sessions as converted, stuck, or dropped for an ordered `steps` list of event names.
 - `/replay/api/friction` computes replay-derived signals such as rage clicks, dead clicks, form thrash, long idle gaps, repeated navigation, and deep scroll without follow-up.
-- `/replay/api/person` joins a distinct ID's replay sessions and analytics events into one journey timeline.
+- `/replay/api/person` joins a distinct ID's replay sessions and product events into one journey timeline.
 - `/replay/api/sessions/:session_id` returns normalized rrweb events plus an activity timeline for one session.
 
 ## Filters

--- a/models/events.yml
+++ b/models/events.yml
@@ -54,7 +54,6 @@ models:
           group3,
           group4,
           group_properties,
-          api_key,
           extra,
           coalesce(
             json_extract_string(properties, '$.$session_id'),
@@ -87,6 +86,14 @@ models:
             json_extract_string(properties, '$.$referrer'),
             json_extract_string(properties, '$.referrer')
           ) as referrer,
+          nullif(regexp_extract(
+            coalesce(
+              json_extract_string(properties, '$.$referrer'),
+              json_extract_string(properties, '$.referrer')
+            ),
+            '^(?:[a-zA-Z][a-zA-Z0-9+.-]*://)?([^/?#]+)',
+            1
+          ), '') as referrer_domain,
           coalesce(
             json_extract_string(properties, '$.$utm_source'),
             json_extract_string(properties, '$.utm_source'),
@@ -188,11 +195,11 @@ models:
       select
         *,
         coalesce(session_id, actor_id || ':' || strftime(event_time, '%Y-%m-%d')) as session_key,
-        event_type not in ('$identify', '$groupidentify', '$create_alias', '$engage', '$snapshot') as is_capture_event,
+        event_type not in ('$identify', '$groupidentify', '$create_alias', '$engage', '$snapshot', '$snapshot_items') as is_capture_event,
         event_type in ('$pageview', 'page_view', '$screen', 'screen') as is_pageview_event,
         event_type in ('$identify', '$engage') as is_person_mutation_event,
         event_type = '$groupidentify' as is_group_event,
-        event_type = '$snapshot' as is_session_recording_event,
+        event_type in ('$snapshot', '$snapshot_items') as is_session_recording_event,
         resolved_person_id is not null as has_person,
         group0 is not null or group1 is not null or group2 is not null or group3 is not null or group4 is not null as has_group,
         session_id is not null as has_session_id
@@ -240,9 +247,6 @@ models:
       - name: team_id
         type: numeric
         description: Optional PostHog team id assigned by the Worker.
-      - name: api_key
-        type: categorical
-        description: PostHog project API key.
       - name: distinct_id
         type: categorical
         description: Original PostHog distinct id.
@@ -285,6 +289,9 @@ models:
       - name: referrer
         type: categorical
         description: Browser referrer.
+      - name: referrer_domain
+        type: categorical
+        description: Domain extracted from the browser referrer.
       - name: utm_source
         type: categorical
         description: UTM source.
@@ -326,15 +333,19 @@ models:
         description: Country code from Cloudflare enrichment or event properties.
       - name: geo_region
         type: categorical
+        parent: geo_country_code
         description: Region/subdivision from Cloudflare enrichment or event properties.
       - name: geo_city
         type: categorical
+        parent: geo_region
         description: City from Cloudflare enrichment or event properties.
       - name: geo_timezone
         type: categorical
+        parent: geo_country_code
         description: Timezone from Cloudflare enrichment.
       - name: cf_colo
         type: categorical
+        parent: geo_country_code
         description: Cloudflare colo.
       - name: cf_asn
         type: numeric
@@ -479,8 +490,8 @@ models:
       - name: snapshot_events
         agg: count
         filters:
-          - "event_type = '$snapshot'"
-        description: Session recording snapshot events.
+          - "event_type in ('$snapshot', '$snapshot_items')"
+        description: Session recording snapshot and normalized snapshot-item events.
       - name: grouped_events
         agg: count
         filters:
@@ -500,10 +511,6 @@ models:
         agg: count_distinct
         sql: coalesce(group0, group1, group2, group3, group4)
         description: Distinct group keys across populated group slots.
-      - name: unique_api_keys
-        agg: count_distinct
-        sql: api_key
-        description: Distinct PostHog project API keys.
       - name: power_users
         type: cohort
         entity: actor_id
@@ -523,6 +530,35 @@ models:
         having: session_count >= 2
         agg: count
         description: Count of actors with at least two sessions in the query scope.
+
+    pre_aggregations:
+      - name: analytics_daily
+        measures:
+          - event_count
+          - pageviews
+          - snapshot_events
+        dimensions:
+          - event_type
+          - pathname
+          - host
+          - referrer_domain
+          - referrer
+          - browser
+          - os
+          - device_type
+          - geo_country_code
+          - geo_region
+          - geo_city
+          - geo_timezone
+          - cf_asn
+          - utm_source
+          - utm_campaign
+        time_dimension: event_time
+        granularity: day
+        partition_granularity: month
+        refresh_key:
+          every: 1 hour
+          incremental: false
 
     segments:
       - name: capture_events
@@ -546,4 +582,3 @@ models:
       - name: session_recordings
         sql: is_session_recording_event
         description: Session recording snapshot events.
-

--- a/models/events.yml
+++ b/models/events.yml
@@ -532,6 +532,33 @@ models:
         description: Count of actors with at least two sessions in the query scope.
 
     pre_aggregations:
+      - name: analytics_hourly
+        measures:
+          - event_count
+          - pageviews
+          - snapshot_events
+        dimensions:
+          - event_type
+          - pathname
+          - host
+          - referrer_domain
+          - referrer
+          - browser
+          - os
+          - device_type
+          - geo_country_code
+          - geo_region
+          - geo_city
+          - geo_timezone
+          - cf_asn
+          - utm_source
+          - utm_campaign
+        time_dimension: event_time
+        granularity: hour
+        partition_granularity: day
+        refresh_key:
+          every: 1 hour
+          incremental: false
       - name: analytics_daily
         measures:
           - event_count

--- a/models/events.yml
+++ b/models/events.yml
@@ -535,6 +535,7 @@ models:
       - name: analytics_hourly
         measures:
           - event_count
+          - capture_events
           - pageviews
           - snapshot_events
         dimensions:
@@ -562,6 +563,7 @@ models:
       - name: analytics_daily
         measures:
           - event_count
+          - capture_events
           - pageviews
           - snapshot_events
         dimensions:

--- a/models/pageviews.yml
+++ b/models/pageviews.yml
@@ -166,6 +166,31 @@ models:
         description: Distinct resolved persons with pageviews.
 
     pre_aggregations:
+      - name: analytics_hourly
+        measures:
+          - pageviews
+        dimensions:
+          - event_type
+          - pathname
+          - host
+          - referrer_domain
+          - referrer
+          - browser
+          - os
+          - device_type
+          - geo_country_code
+          - geo_region
+          - geo_city
+          - geo_timezone
+          - cf_asn
+          - utm_source
+          - utm_campaign
+        time_dimension: event_time
+        granularity: hour
+        partition_granularity: day
+        refresh_key:
+          every: 1 hour
+          incremental: false
       - name: analytics_daily
         measures:
           - pageviews

--- a/models/pageviews.yml
+++ b/models/pageviews.yml
@@ -48,20 +48,29 @@ models:
               group2,
               group3,
               group4,
-              api_key,
               coalesce(json_extract_string(properties, '$.$session_id'), json_extract_string(properties, '$.session_id')) as session_id,
               coalesce(json_extract_string(properties, '$.$current_url'), json_extract_string(properties, '$.current_url'), json_extract_string(properties, '$.url')) as current_url,
               coalesce(json_extract_string(properties, '$.$pathname'), json_extract_string(properties, '$.pathname'), json_extract_string(properties, '$.path')) as pathname,
               coalesce(json_extract_string(properties, '$.$host'), json_extract_string(properties, '$.host')) as host,
               coalesce(json_extract_string(properties, '$.$title'), json_extract_string(properties, '$.title')) as page_title,
               coalesce(json_extract_string(properties, '$.$referrer'), json_extract_string(properties, '$.referrer')) as referrer,
+              nullif(regexp_extract(
+                coalesce(json_extract_string(properties, '$.$referrer'), json_extract_string(properties, '$.referrer')),
+                '^(?:[a-zA-Z][a-zA-Z0-9+.-]*://)?([^/?#]+)',
+                1
+              ), '') as referrer_domain,
               coalesce(json_extract_string(properties, '$.$utm_source'), json_extract_string(properties, '$.utm_source'), json_extract_string(properties, '$.$initial_utm_source')) as utm_source,
               coalesce(json_extract_string(properties, '$.$utm_medium'), json_extract_string(properties, '$.utm_medium'), json_extract_string(properties, '$.$initial_utm_medium')) as utm_medium,
               coalesce(json_extract_string(properties, '$.$utm_campaign'), json_extract_string(properties, '$.utm_campaign'), json_extract_string(properties, '$.$initial_utm_campaign')) as utm_campaign,
               coalesce(json_extract_string(properties, '$.$browser'), json_extract_string(properties, '$.browser')) as browser,
               coalesce(json_extract_string(properties, '$.$os'), json_extract_string(properties, '$.os')) as os,
               coalesce(json_extract_string(properties, '$.$device_type'), json_extract_string(properties, '$.device_type')) as device_type,
-              coalesce(json_extract_string(properties, '$.$geoip_country_code'), json_extract_string(properties, '$.country')) as geo_country_code
+              coalesce(json_extract_string(properties, '$.$geoip_country_code'), json_extract_string(properties, '$.country')) as geo_country_code,
+              coalesce(json_extract_string(properties, '$.$geoip_subdivision_1_code'), json_extract_string(properties, '$.region')) as geo_region,
+              coalesce(json_extract_string(properties, '$.$geoip_city_name'), json_extract_string(properties, '$.city')) as geo_city,
+              json_extract_string(properties, '$.$geoip_time_zone') as geo_timezone,
+              json_extract_string(properties, '$.cf_colo') as cf_colo,
+              try_cast(json_extract_string(properties, '$.cf_asn') as bigint) as cf_asn
             from {{ events_table }}
             left join identity_map on distinct_id = identity_map.linked_distinct_id
           )
@@ -105,6 +114,8 @@ models:
         type: categorical
       - name: referrer
         type: categorical
+      - name: referrer_domain
+        type: categorical
       - name: utm_source
         type: categorical
       - name: utm_medium
@@ -119,6 +130,20 @@ models:
         type: categorical
       - name: geo_country_code
         type: categorical
+      - name: geo_region
+        type: categorical
+        parent: geo_country_code
+      - name: geo_city
+        type: categorical
+        parent: geo_region
+      - name: geo_timezone
+        type: categorical
+        parent: geo_country_code
+      - name: cf_colo
+        type: categorical
+        parent: geo_country_code
+      - name: cf_asn
+        type: numeric
       - name: event_time
         type: time
         granularity: day
@@ -140,3 +165,29 @@ models:
         sql: resolved_person_id
         description: Distinct resolved persons with pageviews.
 
+    pre_aggregations:
+      - name: analytics_daily
+        measures:
+          - pageviews
+        dimensions:
+          - event_type
+          - pathname
+          - host
+          - referrer_domain
+          - referrer
+          - browser
+          - os
+          - device_type
+          - geo_country_code
+          - geo_region
+          - geo_city
+          - geo_timezone
+          - cf_asn
+          - utm_source
+          - utm_campaign
+        time_dimension: event_time
+        granularity: day
+        partition_granularity: month
+        refresh_key:
+          every: 1 hour
+          incremental: false

--- a/models/sessions.yml
+++ b/models/sessions.yml
@@ -219,6 +219,28 @@ models:
         description: Average pageviews per session.
 
     pre_aggregations:
+      - name: analytics_hourly
+        measures:
+          - session_count
+        dimensions:
+          - landing_path
+          - browser
+          - os
+          - device_type
+          - referrer_domain
+          - referrer
+          - geo_country_code
+          - geo_region
+          - geo_city
+          - geo_timezone
+          - cf_asn
+          - utm_source
+        time_dimension: session_start_at
+        granularity: hour
+        partition_granularity: day
+        refresh_key:
+          every: 1 hour
+          incremental: false
       - name: analytics_daily
         measures:
           - session_count

--- a/models/sessions.yml
+++ b/models/sessions.yml
@@ -39,18 +39,27 @@ models:
           identity_map.canonical_distinct_id,
           coalesce(timestamp, created_at) as event_time,
           properties,
-          api_key,
           coalesce(json_extract_string(properties, '$.$session_id'), json_extract_string(properties, '$.session_id')) as session_id,
           coalesce(json_extract_string(properties, '$.$pathname'), json_extract_string(properties, '$.pathname'), json_extract_string(properties, '$.path')) as pathname,
           coalesce(json_extract_string(properties, '$.$current_url'), json_extract_string(properties, '$.current_url'), json_extract_string(properties, '$.url')) as current_url,
           coalesce(json_extract_string(properties, '$.$referrer'), json_extract_string(properties, '$.referrer')) as referrer,
+          nullif(regexp_extract(
+            coalesce(json_extract_string(properties, '$.$referrer'), json_extract_string(properties, '$.referrer')),
+            '^(?:[a-zA-Z][a-zA-Z0-9+.-]*://)?([^/?#]+)',
+            1
+          ), '') as referrer_domain,
           coalesce(json_extract_string(properties, '$.$utm_source'), json_extract_string(properties, '$.utm_source'), json_extract_string(properties, '$.$initial_utm_source')) as utm_source,
           coalesce(json_extract_string(properties, '$.$utm_medium'), json_extract_string(properties, '$.utm_medium'), json_extract_string(properties, '$.$initial_utm_medium')) as utm_medium,
           coalesce(json_extract_string(properties, '$.$utm_campaign'), json_extract_string(properties, '$.utm_campaign'), json_extract_string(properties, '$.$initial_utm_campaign')) as utm_campaign,
           coalesce(json_extract_string(properties, '$.$browser'), json_extract_string(properties, '$.browser')) as browser,
           coalesce(json_extract_string(properties, '$.$os'), json_extract_string(properties, '$.os')) as os,
           coalesce(json_extract_string(properties, '$.$device_type'), json_extract_string(properties, '$.device_type')) as device_type,
-          coalesce(json_extract_string(properties, '$.$geoip_country_code'), json_extract_string(properties, '$.country')) as geo_country_code
+          coalesce(json_extract_string(properties, '$.$geoip_country_code'), json_extract_string(properties, '$.country')) as geo_country_code,
+          coalesce(json_extract_string(properties, '$.$geoip_subdivision_1_code'), json_extract_string(properties, '$.region')) as geo_region,
+          coalesce(json_extract_string(properties, '$.$geoip_city_name'), json_extract_string(properties, '$.city')) as geo_city,
+          json_extract_string(properties, '$.$geoip_time_zone') as geo_timezone,
+          json_extract_string(properties, '$.cf_colo') as cf_colo,
+          try_cast(json_extract_string(properties, '$.cf_asn') as bigint) as cf_asn
         from {{ events_table }}
         left join identity_map on distinct_id = identity_map.linked_distinct_id
         where coalesce(timestamp, created_at) is not null
@@ -68,7 +77,6 @@ models:
         first(resolved_person_id order by event_time asc) as person_id,
         first(canonical_distinct_id order by event_time asc) as canonical_distinct_id,
         true as has_session_id,
-        first(api_key order by event_time asc) as api_key,
         min(event_time) as session_start_at,
         max(event_time) as session_end_at,
         date_diff('second', min(event_time), max(event_time)) as duration_seconds,
@@ -80,13 +88,19 @@ models:
         first(current_url order by event_time asc) as landing_url,
         last(current_url order by event_time asc) as exit_url,
         first(referrer order by event_time asc) as referrer,
+        first(referrer_domain order by event_time asc) as referrer_domain,
         first(utm_source order by event_time asc) as utm_source,
         first(utm_medium order by event_time asc) as utm_medium,
         first(utm_campaign order by event_time asc) as utm_campaign,
         first(browser order by event_time asc) as browser,
         first(os order by event_time asc) as os,
         first(device_type order by event_time asc) as device_type,
-        first(geo_country_code order by event_time asc) as geo_country_code
+        first(geo_country_code order by event_time asc) as geo_country_code,
+        first(geo_region order by event_time asc) as geo_region,
+        first(geo_city order by event_time asc) as geo_city,
+        first(geo_timezone order by event_time asc) as geo_timezone,
+        first(cf_colo order by event_time asc) as cf_colo,
+        first(cf_asn order by event_time asc) as cf_asn
       from sessionized
       group by session_id
     description: Real PostHog SDK session rollup keyed only by captured $session_id.
@@ -113,8 +127,6 @@ models:
         type: categorical
       - name: has_session_id
         type: boolean
-      - name: api_key
-        type: categorical
       - name: landing_path
         type: categorical
       - name: exit_path
@@ -124,6 +136,8 @@ models:
       - name: exit_url
         type: categorical
       - name: referrer
+        type: categorical
+      - name: referrer_domain
         type: categorical
       - name: utm_source
         type: categorical
@@ -139,6 +153,20 @@ models:
         type: categorical
       - name: geo_country_code
         type: categorical
+      - name: geo_region
+        type: categorical
+        parent: geo_country_code
+      - name: geo_city
+        type: categorical
+        parent: geo_region
+      - name: geo_timezone
+        type: categorical
+        parent: geo_country_code
+      - name: cf_colo
+        type: categorical
+        parent: geo_country_code
+      - name: cf_asn
+        type: numeric
       - name: duration_seconds
         type: numeric
       - name: event_count
@@ -190,3 +218,26 @@ models:
         sql: pageview_count
         description: Average pageviews per session.
 
+    pre_aggregations:
+      - name: analytics_daily
+        measures:
+          - session_count
+        dimensions:
+          - landing_path
+          - browser
+          - os
+          - device_type
+          - referrer_domain
+          - referrer
+          - geo_country_code
+          - geo_region
+          - geo_city
+          - geo_timezone
+          - cf_asn
+          - utm_source
+        time_dimension: session_start_at
+        granularity: day
+        partition_granularity: month
+        refresh_key:
+          every: 1 hour
+          incremental: false

--- a/scripts/product_analytics_sidemantic.py
+++ b/scripts/product_analytics_sidemantic.py
@@ -533,6 +533,17 @@ class SidemanticAnalytics:
         )
         focus_time_dimension = TIME_DIMENSIONS[metric["model"]]
         focus_bucket_ref = f"{metric['model']}.{focus_time_dimension}__{granularity}"
+        context_series_rows = self._rows(
+            metrics=[
+                "events.event_count",
+                "events.pageviews",
+                "events.unique_sessions",
+                "events.snapshot_events",
+            ],
+            dimensions=[f"events.event_time__{granularity}"],
+            filters=events_filters,
+            order_by=[f"events.event_time__{granularity}"],
+        )
         focus_series_rows = self._rows(
             metrics=[metric["ref"]],
             dimensions=[focus_bucket_ref],
@@ -798,6 +809,7 @@ class SidemanticAnalytics:
                 count_metric("Replay chunks", replay_chunks, "events", "snapshot_events"),
             ],
             "series": series_points(
+                context_series_rows,
                 focus_series_rows,
                 focus_time_dimension,
                 granularity,
@@ -856,6 +868,17 @@ class SidemanticAnalytics:
         if panel == "series":
             focus_time_dimension = TIME_DIMENSIONS[metric["model"]]
             focus_bucket_ref = f"{metric['model']}.{focus_time_dimension}__{granularity}"
+            context_series_rows = self._rows(
+                metrics=[
+                    "events.event_count",
+                    "events.pageviews",
+                    "events.unique_sessions",
+                    "events.snapshot_events",
+                ],
+                dimensions=[f"events.event_time__{granularity}"],
+                filters=events_filters,
+                order_by=[f"events.event_time__{granularity}"],
+            )
             focus_series_rows = self._rows(
                 metrics=[metric["ref"]],
                 dimensions=[focus_bucket_ref],
@@ -863,6 +886,7 @@ class SidemanticAnalytics:
                 order_by=[focus_bucket_ref],
             )
             response["series"] = series_points(
+                context_series_rows,
                 focus_series_rows,
                 focus_time_dimension,
                 granularity,
@@ -1215,25 +1239,32 @@ def dimension_ref_for_model(source_ref: str, model: str) -> str | None:
 
 
 def series_points(
+    context_rows: list[dict[str, Any]],
     focus_rows: list[dict[str, Any]],
     focus_time_dimension: str,
     granularity: str,
     focus_value_key: str,
 ) -> list[dict[str, Any]]:
+    context_bucket_key = f"event_time__{granularity}"
     focus_bucket_key = f"{focus_time_dimension}__{granularity}"
+    context_by_bucket = {
+        date_label(row.get(context_bucket_key)): row
+        for row in context_rows
+        if row.get(context_bucket_key) is not None
+    }
     focus_by_bucket = {
         date_label(row.get(focus_bucket_key)): row
         for row in focus_rows
         if row.get(focus_bucket_key) is not None
     }
-    buckets = sorted(focus_by_bucket)
+    buckets = sorted(set(context_by_bucket) | set(focus_by_bucket))
     return [
         {
             "bucket": bucket,
-            "event_count": 0,
-            "pageviews": 0,
-            "session_count": 0,
-            "recordings": 0,
+            "event_count": to_int(context_by_bucket.get(bucket, {}).get("event_count")),
+            "pageviews": to_int(context_by_bucket.get(bucket, {}).get("pageviews")),
+            "session_count": to_int(context_by_bucket.get(bucket, {}).get("unique_sessions")),
+            "recordings": to_int(context_by_bucket.get(bucket, {}).get("snapshot_events")),
             "focused_value": to_float(focus_by_bucket.get(bucket, {}).get(focus_value_key)),
         }
         for bucket in buckets

--- a/scripts/product_analytics_sidemantic.py
+++ b/scripts/product_analytics_sidemantic.py
@@ -27,20 +27,24 @@ IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$")
 NUMERIC_LITERAL_RE = re.compile(r"^-?\d+(?:\.\d+)?$")
 GRANULARITIES = {"hour", "day", "week", "month"}
 ANALYTICS_BREAKDOWN_LIMIT = 10
-CHART_PANELS = {
-    "summary",
-    "series",
-    "focus_breakdown",
+LEADERBOARD_PANELS = [
     "top_events",
     "top_pages",
     "domains",
     "referring_domains",
     "referrers",
     "browsers",
+    "operating_systems",
+    "devices",
     "countries",
     "regions",
     "cities",
-}
+    "timezones",
+    "asns",
+    "utm_sources",
+    "utm_campaigns",
+]
+CHART_PANELS = {"summary", "series", "focus_breakdown", *LEADERBOARD_PANELS}
 TIME_DIMENSIONS = {
     "events": "event_time",
     "pageviews": "event_time",
@@ -53,7 +57,9 @@ DEFAULT_DIMENSIONS = {
 }
 BUILTIN_BREAKDOWN_DIMENSIONS = {
     "events.event_type",
+    "events.pathname",
     "pageviews.pathname",
+    "pageviews.event_type",
     "pageviews.host",
     "pageviews.referrer_domain",
     "pageviews.referrer",
@@ -61,6 +67,80 @@ BUILTIN_BREAKDOWN_DIMENSIONS = {
     "events.geo_country_code",
     "events.geo_region",
     "events.geo_city",
+}
+PANEL_DIMENSIONS = {
+    "top_events": {
+        "events": "events.event_type",
+        "pageviews": "pageviews.event_type",
+    },
+    "top_pages": {
+        "events": "events.pathname",
+        "pageviews": "pageviews.pathname",
+        "sessions": "sessions.landing_path",
+    },
+    "domains": {
+        "events": "events.host",
+        "pageviews": "pageviews.host",
+    },
+    "referring_domains": {
+        "events": "events.referrer_domain",
+        "pageviews": "pageviews.referrer_domain",
+        "sessions": "sessions.referrer_domain",
+    },
+    "referrers": {
+        "events": "events.referrer",
+        "pageviews": "pageviews.referrer",
+        "sessions": "sessions.referrer",
+    },
+    "browsers": {
+        "events": "events.browser",
+        "pageviews": "pageviews.browser",
+        "sessions": "sessions.browser",
+    },
+    "operating_systems": {
+        "events": "events.os",
+        "pageviews": "pageviews.os",
+        "sessions": "sessions.os",
+    },
+    "devices": {
+        "events": "events.device_type",
+        "pageviews": "pageviews.device_type",
+        "sessions": "sessions.device_type",
+    },
+    "countries": {
+        "events": "events.geo_country_code",
+        "pageviews": "pageviews.geo_country_code",
+        "sessions": "sessions.geo_country_code",
+    },
+    "regions": {
+        "events": "events.geo_region",
+        "pageviews": "pageviews.geo_region",
+        "sessions": "sessions.geo_region",
+    },
+    "cities": {
+        "events": "events.geo_city",
+        "pageviews": "pageviews.geo_city",
+        "sessions": "sessions.geo_city",
+    },
+    "timezones": {
+        "events": "events.geo_timezone",
+        "pageviews": "pageviews.geo_timezone",
+        "sessions": "sessions.geo_timezone",
+    },
+    "asns": {
+        "events": "events.cf_asn",
+        "pageviews": "pageviews.cf_asn",
+        "sessions": "sessions.cf_asn",
+    },
+    "utm_sources": {
+        "events": "events.utm_source",
+        "pageviews": "pageviews.utm_source",
+        "sessions": "sessions.utm_source",
+    },
+    "utm_campaigns": {
+        "events": "events.utm_campaign",
+        "pageviews": "pageviews.utm_campaign",
+    },
 }
 METRICS = {
     "events.event_count": {
@@ -104,12 +184,25 @@ METRICS = {
         "context_key": "recordings",
     },
 }
+QUERY_METRICS = {
+    "events.event_count",
+    "events.unique_users",
+    "pageviews.pageviews",
+    "sessions.session_count",
+    "sessions.average_session_seconds",
+}
 DIMENSIONS = {
     "events.event_type": {
         "model": "events",
         "dimension": "event_type",
         "label": "Event",
         "title": "Events",
+    },
+    "events.pathname": {
+        "model": "events",
+        "dimension": "pathname",
+        "label": "Page",
+        "title": "Pages",
     },
     "events.browser": {
         "model": "events",
@@ -199,8 +292,14 @@ DIMENSIONS = {
     "pageviews.pathname": {
         "model": "pageviews",
         "dimension": "pathname",
-        "label": "Path",
+        "label": "Page",
         "title": "Pages",
+    },
+    "pageviews.event_type": {
+        "model": "pageviews",
+        "dimension": "event_type",
+        "label": "Event",
+        "title": "Events",
     },
     "pageviews.host": {
         "model": "pageviews",
@@ -224,55 +323,55 @@ DIMENSIONS = {
         "model": "pageviews",
         "dimension": "browser",
         "label": "Browser",
-        "title": "Pageview browsers",
+        "title": "Browsers",
     },
     "pageviews.os": {
         "model": "pageviews",
         "dimension": "os",
         "label": "OS",
-        "title": "Pageview OS",
+        "title": "Operating systems",
     },
     "pageviews.device_type": {
         "model": "pageviews",
         "dimension": "device_type",
         "label": "Device type",
-        "title": "Pageview devices",
+        "title": "Devices",
     },
     "pageviews.geo_country_code": {
         "model": "pageviews",
         "dimension": "geo_country_code",
         "label": "Country",
-        "title": "Pageview countries",
+        "title": "Countries",
     },
     "pageviews.geo_region": {
         "model": "pageviews",
         "dimension": "geo_region",
         "label": "Region",
-        "title": "Pageview regions",
+        "title": "Regions",
     },
     "pageviews.geo_city": {
         "model": "pageviews",
         "dimension": "geo_city",
         "label": "City",
-        "title": "Pageview cities",
+        "title": "Cities",
     },
     "pageviews.geo_timezone": {
         "model": "pageviews",
         "dimension": "geo_timezone",
         "label": "Timezone",
-        "title": "Pageview timezones",
+        "title": "Timezones",
     },
     "pageviews.cf_colo": {
         "model": "pageviews",
         "dimension": "cf_colo",
         "label": "Cloudflare colo",
-        "title": "Pageview Cloudflare colos",
+        "title": "Cloudflare colos",
     },
     "pageviews.cf_asn": {
         "model": "pageviews",
         "dimension": "cf_asn",
         "label": "ASN",
-        "title": "Pageview ASNs",
+        "title": "ASNs",
         "type": "numeric",
     },
     "pageviews.utm_source": {
@@ -297,74 +396,74 @@ DIMENSIONS = {
         "model": "sessions",
         "dimension": "browser",
         "label": "Browser",
-        "title": "Session browsers",
+        "title": "Browsers",
     },
     "sessions.os": {
         "model": "sessions",
         "dimension": "os",
         "label": "OS",
-        "title": "Session OS",
+        "title": "Operating systems",
     },
     "sessions.device_type": {
         "model": "sessions",
         "dimension": "device_type",
         "label": "Device type",
-        "title": "Session devices",
+        "title": "Devices",
     },
     "sessions.referrer_domain": {
         "model": "sessions",
         "dimension": "referrer_domain",
         "label": "Referring domain",
-        "title": "Session referring domains",
+        "title": "Referring domains",
     },
     "sessions.referrer": {
         "model": "sessions",
         "dimension": "referrer",
         "label": "Referrer",
-        "title": "Session referrers",
+        "title": "Referrers",
     },
     "sessions.geo_country_code": {
         "model": "sessions",
         "dimension": "geo_country_code",
         "label": "Country",
-        "title": "Session countries",
+        "title": "Countries",
     },
     "sessions.geo_region": {
         "model": "sessions",
         "dimension": "geo_region",
         "label": "Region",
-        "title": "Session regions",
+        "title": "Regions",
     },
     "sessions.geo_city": {
         "model": "sessions",
         "dimension": "geo_city",
         "label": "City",
-        "title": "Session cities",
+        "title": "Cities",
     },
     "sessions.geo_timezone": {
         "model": "sessions",
         "dimension": "geo_timezone",
         "label": "Timezone",
-        "title": "Session timezones",
+        "title": "Timezones",
     },
     "sessions.cf_colo": {
         "model": "sessions",
         "dimension": "cf_colo",
         "label": "Cloudflare colo",
-        "title": "Session Cloudflare colos",
+        "title": "Cloudflare colos",
     },
     "sessions.cf_asn": {
         "model": "sessions",
         "dimension": "cf_asn",
         "label": "ASN",
-        "title": "Session ASNs",
+        "title": "ASNs",
         "type": "numeric",
     },
     "sessions.utm_source": {
         "model": "sessions",
         "dimension": "utm_source",
         "label": "UTM source",
-        "title": "Session UTM sources",
+        "title": "UTM sources",
     },
 }
 
@@ -517,7 +616,7 @@ class SidemanticAnalytics:
             )
 
         events_summary = self._one(
-            metrics=["events.event_count", "events.unique_users", "events.snapshot_events"],
+            metrics=["events.event_count", "events.unique_users"],
             filters=events_filters,
             skip_default_time_dimensions=True,
         )
@@ -550,11 +649,6 @@ class SidemanticAnalytics:
             filters=focus_filters,
             order_by=[focus_bucket_ref],
         )
-        focus_total = self._one(
-            metrics=[metric["ref"]],
-            filters=focus_filters,
-            skip_default_time_dimensions=True,
-        )
         focus_breakdown_filters = [
             *self._filters_for(metric["model"], query, exclude_dimension_ref=dimension["ref"]),
             f"{dimension['ref']} is not null",
@@ -572,117 +666,16 @@ class SidemanticAnalytics:
             metric["metric"],
             focus_breakdown_filters,
         )
-        top_events = self._rows(
-            metrics=["events.event_count"],
-            dimensions=["events.event_type"],
-            filters=[
-                *self._filters_for("events", query, exclude_dimension_ref="events.event_type"),
-                "events.event_type is not null",
-            ],
-            order_by=["events.event_count DESC"],
-            limit=top_limit,
-            skip_default_time_dimensions=True,
-        )
-        top_pages = self._rows(
-            metrics=["pageviews.pageviews"],
-            dimensions=["pageviews.pathname"],
-            filters=[
-                *self._filters_for("pageviews", query, exclude_dimension_ref="pageviews.pathname"),
-                "pageviews.pathname is not null",
-            ],
-            order_by=["pageviews.pageviews DESC"],
-            limit=top_limit,
-            skip_default_time_dimensions=True,
-        )
-        domains = self._rows(
-            metrics=["pageviews.pageviews"],
-            dimensions=["pageviews.host"],
-            filters=[
-                *self._filters_for("pageviews", query, exclude_dimension_ref="pageviews.host"),
-                "pageviews.host is not null",
-            ],
-            order_by=["pageviews.pageviews DESC"],
-            limit=top_limit,
-            skip_default_time_dimensions=True,
-        )
-        referring_domains = self._rows(
-            metrics=["pageviews.pageviews"],
-            dimensions=["pageviews.referrer_domain"],
-            filters=[
-                *self._filters_for("pageviews", query, exclude_dimension_ref="pageviews.referrer_domain"),
-                "pageviews.referrer_domain is not null",
-            ],
-            order_by=["pageviews.pageviews DESC"],
-            limit=top_limit,
-            skip_default_time_dimensions=True,
-        )
-        referrers = self._rows(
-            metrics=["pageviews.pageviews"],
-            dimensions=["pageviews.referrer"],
-            filters=[
-                *self._filters_for("pageviews", query, exclude_dimension_ref="pageviews.referrer"),
-                "pageviews.referrer is not null",
-            ],
-            order_by=["pageviews.pageviews DESC"],
-            limit=top_limit,
-            skip_default_time_dimensions=True,
-        )
-        browsers = self._rows(
-            metrics=["events.event_count"],
-            dimensions=["events.browser"],
-            filters=[
-                *self._filters_for("events", query, exclude_dimension_ref="events.browser"),
-                "events.browser is not null",
-            ],
-            order_by=["events.event_count DESC"],
-            limit=top_limit,
-            skip_default_time_dimensions=True,
-        )
-        countries = self._rows(
-            metrics=["events.event_count"],
-            dimensions=["events.geo_country_code"],
-            filters=[
-                *self._filters_for("events", query, exclude_dimension_ref="events.geo_country_code"),
-                "events.geo_country_code is not null",
-            ],
-            order_by=["events.event_count DESC"],
-            limit=top_limit,
-            skip_default_time_dimensions=True,
-        )
-        regions = self._rows(
-            metrics=["events.event_count"],
-            dimensions=["events.geo_region"],
-            filters=[
-                *self._filters_for("events", query, exclude_dimension_ref="events.geo_region"),
-                "events.geo_region is not null",
-            ],
-            order_by=["events.event_count DESC"],
-            limit=top_limit,
-            skip_default_time_dimensions=True,
-        )
-        cities = self._rows(
-            metrics=["events.event_count"],
-            dimensions=["events.geo_city"],
-            filters=[
-                *self._filters_for("events", query, exclude_dimension_ref="events.geo_city"),
-                "events.geo_city is not null",
-            ],
-            order_by=["events.event_count DESC"],
-            limit=top_limit,
-            skip_default_time_dimensions=True,
-        )
 
         event_count = to_int(events_summary.get("event_count"))
         pageviews = to_int(pageviews_summary.get("pageviews"))
         unique_users = to_int(events_summary.get("unique_users"))
         session_count = to_int(sessions_summary.get("session_count"))
         average_session_seconds = to_float(sessions_summary.get("average_session_seconds"))
-        replay_chunks = to_int(events_summary.get("snapshot_events"))
-        focus_value = to_float(focus_total.get(metric["metric"]))
 
         breakdowns = [
             breakdown(
-                f"{metric['label']} by {dimension['label']}",
+                dimension["title"],
                 dimension["model"],
                 dimension["dimension"],
                 metric["ref"],
@@ -692,98 +685,10 @@ class SidemanticAnalytics:
                 focus_breakdown_total,
             )
         ]
-        for candidate in [
-            breakdown(
-                "Events by Event",
-                "events",
-                "event_type",
-                "events.event_count",
-                top_events,
-                "event_type",
-                "event_count",
-                event_count,
-            ),
-            breakdown(
-                "Pageviews by Page",
-                "pageviews",
-                "pathname",
-                "pageviews.pageviews",
-                top_pages,
-                "pathname",
-                "pageviews",
-                pageviews,
-            ),
-            breakdown(
-                "Pageviews by Domain",
-                "pageviews",
-                "host",
-                "pageviews.pageviews",
-                domains,
-                "host",
-                "pageviews",
-                pageviews,
-            ),
-            breakdown(
-                "Pageviews by Referring domain",
-                "pageviews",
-                "referrer_domain",
-                "pageviews.pageviews",
-                referring_domains,
-                "referrer_domain",
-                "pageviews",
-                pageviews,
-            ),
-            breakdown(
-                "Pageviews by Referrer",
-                "pageviews",
-                "referrer",
-                "pageviews.pageviews",
-                referrers,
-                "referrer",
-                "pageviews",
-                pageviews,
-            ),
-            breakdown(
-                "Events by Browser",
-                "events",
-                "browser",
-                "events.event_count",
-                browsers,
-                "browser",
-                "event_count",
-                event_count,
-            ),
-            breakdown(
-                "Events by Country",
-                "events",
-                "geo_country_code",
-                "events.event_count",
-                countries,
-                "geo_country_code",
-                "event_count",
-                event_count,
-            ),
-            breakdown(
-                "Events by Region",
-                "events",
-                "geo_region",
-                "events.event_count",
-                regions,
-                "geo_region",
-                "event_count",
-                event_count,
-            ),
-            breakdown(
-                "Events by City",
-                "events",
-                "geo_city",
-                "events.event_count",
-                cities,
-                "geo_city",
-                "event_count",
-                event_count,
-            ),
-        ]:
+        for panel in panel_keys_for_metric(metric):
+            candidate = self._leaderboard_panel(panel, query, top_limit, metric)
+            if not candidate:
+                continue
             if not any(same_breakdown(candidate, existing) for existing in breakdowns):
                 breakdowns.append(candidate)
 
@@ -806,7 +711,6 @@ class SidemanticAnalytics:
                     "sessions",
                     "average_session_seconds",
                 ),
-                count_metric("Replay chunks", replay_chunks, "events", "snapshot_events"),
             ],
             "series": series_points(
                 context_series_rows,
@@ -836,7 +740,7 @@ class SidemanticAnalytics:
 
         if panel == "summary":
             events_summary = self._one(
-                metrics=["events.event_count", "events.unique_users", "events.snapshot_events"],
+                metrics=["events.event_count", "events.unique_users"],
                 filters=events_filters,
                 skip_default_time_dimensions=True,
             )
@@ -861,7 +765,6 @@ class SidemanticAnalytics:
                     "sessions",
                     "average_session_seconds",
                 ),
-                count_metric("Replay chunks", to_int(events_summary.get("snapshot_events")), "events", "snapshot_events"),
             ]
             return response
 
@@ -914,7 +817,7 @@ class SidemanticAnalytics:
             )
             response["breakdowns"] = [
                 breakdown(
-                    f"{metric['label']} by {dimension['label']}",
+                    dimension["title"],
                     dimension["model"],
                     dimension["dimension"],
                     metric["ref"],
@@ -926,7 +829,7 @@ class SidemanticAnalytics:
             ]
             return response
 
-        leaderboard = self._leaderboard_panel(panel, query, top_limit)
+        leaderboard = self._leaderboard_panel(panel, query, top_limit, metric)
         if leaderboard:
             response["breakdowns"] = [leaderboard]
         return response
@@ -936,43 +839,35 @@ class SidemanticAnalytics:
         panel: str,
         query: dict[str, Any],
         top_limit: int,
+        metric: dict[str, Any],
     ) -> dict[str, Any] | None:
-        configs = {
-            "top_events": ("Events by Event", "events", "event_type", "events.event_count", "event_count"),
-            "top_pages": ("Pageviews by Page", "pageviews", "pathname", "pageviews.pageviews", "pageviews"),
-            "domains": ("Pageviews by Domain", "pageviews", "host", "pageviews.pageviews", "pageviews"),
-            "referring_domains": (
-                "Pageviews by Referring domain",
-                "pageviews",
-                "referrer_domain",
-                "pageviews.pageviews",
-                "pageviews",
-            ),
-            "referrers": ("Pageviews by Referrer", "pageviews", "referrer", "pageviews.pageviews", "pageviews"),
-            "browsers": ("Events by Browser", "events", "browser", "events.event_count", "event_count"),
-            "countries": ("Events by Country", "events", "geo_country_code", "events.event_count", "event_count"),
-            "regions": ("Events by Region", "events", "geo_region", "events.event_count", "event_count"),
-            "cities": ("Events by City", "events", "geo_city", "events.event_count", "event_count"),
-        }
-        config = configs.get(panel)
-        if not config:
+        dimension_ref = PANEL_DIMENSIONS.get(panel, {}).get(metric["model"])
+        if not dimension_ref:
             return None
-        title, model, dimension, metric_ref, value_key = config
-        dimension_ref = f"{model}.{dimension}"
+        dimension_defn = DIMENSIONS[dimension_ref]
         filters = [
-            *self._filters_for(model, query, exclude_dimension_ref=dimension_ref),
+            *self._filters_for(metric["model"], query, exclude_dimension_ref=dimension_ref),
             f"{dimension_ref} is not null",
         ]
         rows = self._rows(
-            metrics=[metric_ref],
+            metrics=[metric["ref"]],
             dimensions=[dimension_ref],
             filters=filters,
-            order_by=[f"{metric_ref} DESC"],
+            order_by=[f"{metric['ref']} DESC"],
             limit=top_limit,
             skip_default_time_dimensions=True,
         )
-        total = self._metric_total(metric_ref, value_key, filters)
-        return breakdown(title, model, dimension, metric_ref, rows, dimension, value_key, total)
+        total = self._metric_total(metric["ref"], metric["metric"], filters)
+        return breakdown(
+            dimension_defn["title"],
+            dimension_defn["model"],
+            dimension_defn["dimension"],
+            metric["ref"],
+            rows,
+            dimension_defn["dimension"],
+            metric["metric"],
+            total,
+        )
 
     @staticmethod
     def _empty_response(metric: dict[str, Any], dimension: dict[str, Any], granularity: str) -> dict[str, Any]:
@@ -1151,8 +1046,8 @@ class SidemanticAnalytics:
 
 def metric_def(value: Any) -> dict[str, Any]:
     ref = clean(value) or "events.event_count"
-    if ref not in METRICS:
-        ref = "events.event_count"
+    if ref not in QUERY_METRICS:
+        raise ValueError(f"Unsupported analytics metric: {ref}")
     metric = dict(METRICS[ref])
     metric["ref"] = ref
     return metric
@@ -1170,6 +1065,14 @@ def dimension_def(value: Any, model: str) -> dict[str, Any]:
 def granularity_for(value: Any) -> str:
     granularity = clean(value) or "day"
     return granularity if granularity in GRANULARITIES else "day"
+
+
+def panel_keys_for_metric(metric: dict[str, Any]) -> list[str]:
+    return [
+        panel
+        for panel in LEADERBOARD_PANELS
+        if metric["model"] in PANEL_DIMENSIONS.get(panel, {})
+    ]
 
 
 def semantic_filters_for(

--- a/scripts/product_analytics_sidemantic.py
+++ b/scripts/product_analytics_sidemantic.py
@@ -143,9 +143,9 @@ PANEL_DIMENSIONS = {
     },
 }
 METRICS = {
-    "events.event_count": {
+    "events.capture_events": {
         "model": "events",
-        "metric": "event_count",
+        "metric": "capture_events",
         "label": "Events",
         "display": "count",
         "context_key": "event_count",
@@ -185,11 +185,14 @@ METRICS = {
     },
 }
 QUERY_METRICS = {
-    "events.event_count",
+    "events.capture_events",
     "events.unique_users",
     "pageviews.pageviews",
     "sessions.session_count",
     "sessions.average_session_seconds",
+}
+METRIC_ALIASES = {
+    "events.event_count": "events.capture_events",
 }
 DIMENSIONS = {
     "events.event_type": {
@@ -507,6 +510,7 @@ class AnalyticsConfig:
         persons_table: str,
         model_dir: Path,
         preagg_enabled: bool,
+        preagg_refresh: bool,
         preagg_schema: str,
     ) -> None:
         self.account_id = account_id
@@ -516,6 +520,7 @@ class AnalyticsConfig:
         self.persons_table = persons_table
         self.model_dir = model_dir
         self.preagg_enabled = preagg_enabled
+        self.preagg_refresh = preagg_refresh
         self.preagg_schema = preagg_schema
 
     @classmethod
@@ -552,6 +557,7 @@ class AnalyticsConfig:
                 or "models"
             ),
             preagg_enabled=env_flag("HOGFLARE_ANALYTICS_PREAGG", default=True),
+            preagg_refresh=env_flag("HOGFLARE_ANALYTICS_PREAGG_REFRESH", default=False),
             preagg_schema=preagg_schema,
         )
 
@@ -616,7 +622,7 @@ class SidemanticAnalytics:
             )
 
         events_summary = self._one(
-            metrics=["events.event_count", "events.unique_users"],
+            metrics=["events.capture_events", "events.unique_users"],
             filters=events_filters,
             skip_default_time_dimensions=True,
         )
@@ -634,7 +640,7 @@ class SidemanticAnalytics:
         focus_bucket_ref = f"{metric['model']}.{focus_time_dimension}__{granularity}"
         context_series_rows = self._rows(
             metrics=[
-                "events.event_count",
+                "events.capture_events",
                 "events.pageviews",
                 "events.unique_sessions",
                 "events.snapshot_events",
@@ -667,7 +673,7 @@ class SidemanticAnalytics:
             focus_breakdown_filters,
         )
 
-        event_count = to_int(events_summary.get("event_count"))
+        event_count = to_int(events_summary.get("capture_events"))
         pageviews = to_int(pageviews_summary.get("pageviews"))
         unique_users = to_int(events_summary.get("unique_users"))
         session_count = to_int(sessions_summary.get("session_count"))
@@ -701,7 +707,7 @@ class SidemanticAnalytics:
                 "granularity": granularity,
             },
             "summary": [
-                count_metric("Events", event_count, "events", "event_count"),
+                count_metric("Events", event_count, "events", "capture_events"),
                 count_metric("Pageviews", pageviews, "pageviews", "pageviews"),
                 count_metric("Users", unique_users, "events", "unique_users"),
                 count_metric("SDK sessions", session_count, "sessions", "session_count"),
@@ -740,7 +746,7 @@ class SidemanticAnalytics:
 
         if panel == "summary":
             events_summary = self._one(
-                metrics=["events.event_count", "events.unique_users"],
+                metrics=["events.capture_events", "events.unique_users"],
                 filters=events_filters,
                 skip_default_time_dimensions=True,
             )
@@ -755,7 +761,7 @@ class SidemanticAnalytics:
                 skip_default_time_dimensions=True,
             )
             response["summary"] = [
-                count_metric("Events", to_int(events_summary.get("event_count")), "events", "event_count"),
+                count_metric("Events", to_int(events_summary.get("capture_events")), "events", "capture_events"),
                 count_metric("Pageviews", to_int(pageviews_summary.get("pageviews")), "pageviews", "pageviews"),
                 count_metric("Users", to_int(events_summary.get("unique_users")), "events", "unique_users"),
                 count_metric("SDK sessions", to_int(sessions_summary.get("session_count")), "sessions", "session_count"),
@@ -773,7 +779,7 @@ class SidemanticAnalytics:
             focus_bucket_ref = f"{metric['model']}.{focus_time_dimension}__{granularity}"
             context_series_rows = self._rows(
                 metrics=[
-                    "events.event_count",
+                    "events.capture_events",
                     "events.pageviews",
                     "events.unique_sessions",
                     "events.snapshot_events",
@@ -943,7 +949,7 @@ class SidemanticAnalytics:
         return [dict(zip(columns, row, strict=False)) for row in relation.fetchall()]
 
     def _materialize_preaggregations(self) -> None:
-        if not self.config.preagg_enabled:
+        if not self.config.preagg_enabled or not self.config.preagg_refresh:
             return
         con = self.layer.adapter.raw_connection
         con.execute(f"CREATE SCHEMA IF NOT EXISTS {self.config.preagg_schema}")
@@ -1045,7 +1051,8 @@ class SidemanticAnalytics:
 
 
 def metric_def(value: Any) -> dict[str, Any]:
-    ref = clean(value) or "events.event_count"
+    ref = clean(value) or "events.capture_events"
+    ref = METRIC_ALIASES.get(ref, ref)
     if ref not in QUERY_METRICS:
         raise ValueError(f"Unsupported analytics metric: {ref}")
     metric = dict(METRICS[ref])
@@ -1151,12 +1158,12 @@ def series_points(
     context_bucket_key = f"event_time__{granularity}"
     focus_bucket_key = f"{focus_time_dimension}__{granularity}"
     context_by_bucket = {
-        date_label(row.get(context_bucket_key)): row
+        date_label(row.get(context_bucket_key), granularity): row
         for row in context_rows
         if row.get(context_bucket_key) is not None
     }
     focus_by_bucket = {
-        date_label(row.get(focus_bucket_key)): row
+        date_label(row.get(focus_bucket_key), granularity): row
         for row in focus_rows
         if row.get(focus_bucket_key) is not None
     }
@@ -1164,7 +1171,7 @@ def series_points(
     return [
         {
             "bucket": bucket,
-            "event_count": to_int(context_by_bucket.get(bucket, {}).get("event_count")),
+            "event_count": to_int(context_by_bucket.get(bucket, {}).get("capture_events")),
             "pageviews": to_int(context_by_bucket.get(bucket, {}).get("pageviews")),
             "session_count": to_int(context_by_bucket.get(bucket, {}).get("unique_sessions")),
             "recordings": to_int(context_by_bucket.get(bucket, {}).get("snapshot_events")),
@@ -1311,8 +1318,10 @@ def format_count(value: int) -> str:
     return f"{value:,}"
 
 
-def date_label(value: Any) -> str:
+def date_label(value: Any, granularity: str = "day") -> str:
     if isinstance(value, datetime):
+        if granularity == "hour":
+            return value.replace(minute=0, second=0, microsecond=0).isoformat()
         return value.date().isoformat()
     if isinstance(value, date):
         return value.isoformat()

--- a/scripts/product_analytics_sidemantic.py
+++ b/scripts/product_analytics_sidemantic.py
@@ -25,7 +25,7 @@ SNAPSHOT_EVENT = "$snapshot"
 SNAPSHOT_ITEMS_EVENT = "$snapshot_items"
 IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$")
 NUMERIC_LITERAL_RE = re.compile(r"^-?\d+(?:\.\d+)?$")
-GRANULARITIES = {"day", "week", "month"}
+GRANULARITIES = {"hour", "day", "week", "month"}
 ANALYTICS_BREAKDOWN_LIMIT = 10
 CHART_PANELS = {
     "summary",

--- a/scripts/product_analytics_sidemantic.py
+++ b/scripts/product_analytics_sidemantic.py
@@ -1,0 +1,1454 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "duckdb>=1.1",
+#   "sidemantic @ git+https://github.com/sidequery/sidemantic",
+# ]
+# ///
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+from sidemantic import SemanticLayer, load_from_directory
+from sidemantic.sql.generator import SQLGenerator
+
+
+SNAPSHOT_EVENT = "$snapshot"
+SNAPSHOT_ITEMS_EVENT = "$snapshot_items"
+IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$")
+NUMERIC_LITERAL_RE = re.compile(r"^-?\d+(?:\.\d+)?$")
+GRANULARITIES = {"day", "week", "month"}
+ANALYTICS_BREAKDOWN_LIMIT = 10
+CHART_PANELS = {
+    "summary",
+    "series",
+    "focus_breakdown",
+    "top_events",
+    "top_pages",
+    "domains",
+    "referring_domains",
+    "referrers",
+    "browsers",
+    "countries",
+    "regions",
+    "cities",
+}
+TIME_DIMENSIONS = {
+    "events": "event_time",
+    "pageviews": "event_time",
+    "sessions": "session_start_at",
+}
+DEFAULT_DIMENSIONS = {
+    "events": "events.event_type",
+    "pageviews": "pageviews.pathname",
+    "sessions": "sessions.landing_path",
+}
+BUILTIN_BREAKDOWN_DIMENSIONS = {
+    "events.event_type",
+    "pageviews.pathname",
+    "pageviews.host",
+    "pageviews.referrer_domain",
+    "pageviews.referrer",
+    "events.browser",
+    "events.geo_country_code",
+    "events.geo_region",
+    "events.geo_city",
+}
+METRICS = {
+    "events.event_count": {
+        "model": "events",
+        "metric": "event_count",
+        "label": "Events",
+        "display": "count",
+        "context_key": "event_count",
+    },
+    "pageviews.pageviews": {
+        "model": "pageviews",
+        "metric": "pageviews",
+        "label": "Pageviews",
+        "display": "count",
+        "context_key": "pageviews",
+    },
+    "events.unique_users": {
+        "model": "events",
+        "metric": "unique_users",
+        "label": "Users",
+        "display": "count",
+    },
+    "sessions.session_count": {
+        "model": "sessions",
+        "metric": "session_count",
+        "label": "SDK sessions",
+        "display": "count",
+        "context_key": "session_count",
+    },
+    "sessions.average_session_seconds": {
+        "model": "sessions",
+        "metric": "average_session_seconds",
+        "label": "Avg session",
+        "display": "seconds",
+    },
+    "events.snapshot_events": {
+        "model": "events",
+        "metric": "snapshot_events",
+        "label": "Replay chunks",
+        "display": "count",
+        "context_key": "recordings",
+    },
+}
+DIMENSIONS = {
+    "events.event_type": {
+        "model": "events",
+        "dimension": "event_type",
+        "label": "Event",
+        "title": "Events",
+    },
+    "events.browser": {
+        "model": "events",
+        "dimension": "browser",
+        "label": "Browser",
+        "title": "Browsers",
+    },
+    "events.os": {
+        "model": "events",
+        "dimension": "os",
+        "label": "OS",
+        "title": "Operating systems",
+    },
+    "events.device_type": {
+        "model": "events",
+        "dimension": "device_type",
+        "label": "Device type",
+        "title": "Devices",
+    },
+    "events.host": {
+        "model": "events",
+        "dimension": "host",
+        "label": "Host",
+        "title": "Domains",
+    },
+    "events.referrer_domain": {
+        "model": "events",
+        "dimension": "referrer_domain",
+        "label": "Referring domain",
+        "title": "Referring domains",
+    },
+    "events.referrer": {
+        "model": "events",
+        "dimension": "referrer",
+        "label": "Referrer",
+        "title": "Referrers",
+    },
+    "events.geo_country_code": {
+        "model": "events",
+        "dimension": "geo_country_code",
+        "label": "Country",
+        "title": "Countries",
+    },
+    "events.geo_region": {
+        "model": "events",
+        "dimension": "geo_region",
+        "label": "Region",
+        "title": "Regions",
+    },
+    "events.geo_city": {
+        "model": "events",
+        "dimension": "geo_city",
+        "label": "City",
+        "title": "Cities",
+    },
+    "events.geo_timezone": {
+        "model": "events",
+        "dimension": "geo_timezone",
+        "label": "Timezone",
+        "title": "Timezones",
+    },
+    "events.cf_colo": {
+        "model": "events",
+        "dimension": "cf_colo",
+        "label": "Cloudflare colo",
+        "title": "Cloudflare colos",
+    },
+    "events.cf_asn": {
+        "model": "events",
+        "dimension": "cf_asn",
+        "label": "ASN",
+        "title": "ASNs",
+        "type": "numeric",
+    },
+    "events.utm_source": {
+        "model": "events",
+        "dimension": "utm_source",
+        "label": "UTM source",
+        "title": "UTM sources",
+    },
+    "events.utm_campaign": {
+        "model": "events",
+        "dimension": "utm_campaign",
+        "label": "UTM campaign",
+        "title": "UTM campaigns",
+    },
+    "pageviews.pathname": {
+        "model": "pageviews",
+        "dimension": "pathname",
+        "label": "Path",
+        "title": "Pages",
+    },
+    "pageviews.host": {
+        "model": "pageviews",
+        "dimension": "host",
+        "label": "Host",
+        "title": "Domains",
+    },
+    "pageviews.referrer_domain": {
+        "model": "pageviews",
+        "dimension": "referrer_domain",
+        "label": "Referring domain",
+        "title": "Referring domains",
+    },
+    "pageviews.referrer": {
+        "model": "pageviews",
+        "dimension": "referrer",
+        "label": "Referrer",
+        "title": "Referrers",
+    },
+    "pageviews.browser": {
+        "model": "pageviews",
+        "dimension": "browser",
+        "label": "Browser",
+        "title": "Pageview browsers",
+    },
+    "pageviews.os": {
+        "model": "pageviews",
+        "dimension": "os",
+        "label": "OS",
+        "title": "Pageview OS",
+    },
+    "pageviews.device_type": {
+        "model": "pageviews",
+        "dimension": "device_type",
+        "label": "Device type",
+        "title": "Pageview devices",
+    },
+    "pageviews.geo_country_code": {
+        "model": "pageviews",
+        "dimension": "geo_country_code",
+        "label": "Country",
+        "title": "Pageview countries",
+    },
+    "pageviews.geo_region": {
+        "model": "pageviews",
+        "dimension": "geo_region",
+        "label": "Region",
+        "title": "Pageview regions",
+    },
+    "pageviews.geo_city": {
+        "model": "pageviews",
+        "dimension": "geo_city",
+        "label": "City",
+        "title": "Pageview cities",
+    },
+    "pageviews.geo_timezone": {
+        "model": "pageviews",
+        "dimension": "geo_timezone",
+        "label": "Timezone",
+        "title": "Pageview timezones",
+    },
+    "pageviews.cf_colo": {
+        "model": "pageviews",
+        "dimension": "cf_colo",
+        "label": "Cloudflare colo",
+        "title": "Pageview Cloudflare colos",
+    },
+    "pageviews.cf_asn": {
+        "model": "pageviews",
+        "dimension": "cf_asn",
+        "label": "ASN",
+        "title": "Pageview ASNs",
+        "type": "numeric",
+    },
+    "pageviews.utm_source": {
+        "model": "pageviews",
+        "dimension": "utm_source",
+        "label": "UTM source",
+        "title": "UTM sources",
+    },
+    "pageviews.utm_campaign": {
+        "model": "pageviews",
+        "dimension": "utm_campaign",
+        "label": "UTM campaign",
+        "title": "UTM campaigns",
+    },
+    "sessions.landing_path": {
+        "model": "sessions",
+        "dimension": "landing_path",
+        "label": "Landing path",
+        "title": "Landing paths",
+    },
+    "sessions.browser": {
+        "model": "sessions",
+        "dimension": "browser",
+        "label": "Browser",
+        "title": "Session browsers",
+    },
+    "sessions.os": {
+        "model": "sessions",
+        "dimension": "os",
+        "label": "OS",
+        "title": "Session OS",
+    },
+    "sessions.device_type": {
+        "model": "sessions",
+        "dimension": "device_type",
+        "label": "Device type",
+        "title": "Session devices",
+    },
+    "sessions.referrer_domain": {
+        "model": "sessions",
+        "dimension": "referrer_domain",
+        "label": "Referring domain",
+        "title": "Session referring domains",
+    },
+    "sessions.referrer": {
+        "model": "sessions",
+        "dimension": "referrer",
+        "label": "Referrer",
+        "title": "Session referrers",
+    },
+    "sessions.geo_country_code": {
+        "model": "sessions",
+        "dimension": "geo_country_code",
+        "label": "Country",
+        "title": "Session countries",
+    },
+    "sessions.geo_region": {
+        "model": "sessions",
+        "dimension": "geo_region",
+        "label": "Region",
+        "title": "Session regions",
+    },
+    "sessions.geo_city": {
+        "model": "sessions",
+        "dimension": "geo_city",
+        "label": "City",
+        "title": "Session cities",
+    },
+    "sessions.geo_timezone": {
+        "model": "sessions",
+        "dimension": "geo_timezone",
+        "label": "Timezone",
+        "title": "Session timezones",
+    },
+    "sessions.cf_colo": {
+        "model": "sessions",
+        "dimension": "cf_colo",
+        "label": "Cloudflare colo",
+        "title": "Session Cloudflare colos",
+    },
+    "sessions.cf_asn": {
+        "model": "sessions",
+        "dimension": "cf_asn",
+        "label": "ASN",
+        "title": "Session ASNs",
+        "type": "numeric",
+    },
+    "sessions.utm_source": {
+        "model": "sessions",
+        "dimension": "utm_source",
+        "label": "UTM source",
+        "title": "Session UTM sources",
+    },
+}
+
+
+def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] == "--serve":
+        serve()
+        return
+
+    query = json.loads(sys.argv[1]) if len(sys.argv) > 1 else json.load(sys.stdin)
+    config = AnalyticsConfig.from_env()
+    runner = SidemanticAnalytics(config)
+    print(json.dumps(runner.run(query), separators=(",", ":")))
+
+
+def serve() -> None:
+    config = AnalyticsConfig.from_env()
+    runner = SidemanticAnalytics(config)
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        request_id = None
+        try:
+            query = json.loads(line)
+            request_id = query.get("_request_id")
+            response = {"ok": True, "request_id": request_id, "result": runner.run(query)}
+        except Exception as exc:
+            response = {"ok": False, "request_id": request_id, "error": str(exc)}
+        print(json.dumps(response, separators=(",", ":")), flush=True)
+
+
+class AnalyticsConfig:
+    def __init__(
+        self,
+        *,
+        account_id: str,
+        bucket: str,
+        token: str,
+        events_table: str,
+        persons_table: str,
+        model_dir: Path,
+        preagg_enabled: bool,
+        preagg_schema: str,
+    ) -> None:
+        self.account_id = account_id
+        self.bucket = bucket
+        self.token = token
+        self.events_table = events_table
+        self.persons_table = persons_table
+        self.model_dir = model_dir
+        self.preagg_enabled = preagg_enabled
+        self.preagg_schema = preagg_schema
+
+    @classmethod
+    def from_env(cls) -> "AnalyticsConfig":
+        events_table = env_required_any("HOGFLARE_ANALYTICS_EVENTS_TABLE", "HOGFLARE_REPLAY_EVENTS_TABLE")
+        persons_table = (
+            os.environ.get("HOGFLARE_ANALYTICS_PERSONS_TABLE")
+            or infer_persons_table(events_table)
+        )
+        for name, value in {
+            "HOGFLARE_ANALYTICS_EVENTS_TABLE": events_table,
+            "HOGFLARE_ANALYTICS_PERSONS_TABLE": persons_table,
+        }.items():
+            if not IDENTIFIER_RE.match(value):
+                raise ValueError(f"{name} must be a dotted SQL identifier")
+        preagg_schema = (
+            os.environ.get("HOGFLARE_ANALYTICS_PREAGG_SCHEMA")
+            or "sidemantic_preagg"
+        )
+        if not IDENTIFIER_RE.match(preagg_schema):
+            raise ValueError("HOGFLARE_ANALYTICS_PREAGG_SCHEMA must be a SQL identifier")
+
+        return cls(
+            account_id=env_required_any("HOGFLARE_ANALYTICS_ACCOUNT_ID", "HOGFLARE_REPLAY_ACCOUNT_ID"),
+            bucket=env_required_any("HOGFLARE_ANALYTICS_BUCKET", "HOGFLARE_REPLAY_BUCKET"),
+            token=env_required_any(
+                "HOGFLARE_ANALYTICS_R2_SQL_TOKEN",
+                "HOGFLARE_REPLAY_R2_SQL_TOKEN",
+            ),
+            events_table=events_table,
+            persons_table=persons_table,
+            model_dir=Path(
+                os.environ.get("HOGFLARE_ANALYTICS_MODEL_DIR")
+                or "models"
+            ),
+            preagg_enabled=env_flag("HOGFLARE_ANALYTICS_PREAGG", default=True),
+            preagg_schema=preagg_schema,
+        )
+
+    @property
+    def warehouse_name(self) -> str:
+        return f"{self.account_id}_{self.bucket}"
+
+    @property
+    def catalog_endpoint(self) -> str:
+        return f"https://catalog.cloudflarestorage.com/{self.account_id}/{self.bucket}"
+
+    @property
+    def attached_events_table(self) -> str:
+        return f"iceberg_catalog.{self.events_table}"
+
+    @property
+    def attached_persons_table(self) -> str:
+        return f"iceberg_catalog.{self.persons_table}"
+
+
+class SidemanticAnalytics:
+    def __init__(self, config: AnalyticsConfig) -> None:
+        self.config = config
+        self.layer = SemanticLayer(
+            connection="duckdb:///:memory:",
+            auto_register=False,
+            use_preaggregations=config.preagg_enabled,
+            preagg_schema=config.preagg_schema,
+        )
+        self._connect_iceberg()
+        load_from_directory(self.layer, str(config.model_dir))
+        self._bind_model_tables()
+        self._materialize_preaggregations()
+        self.generator = SQLGenerator(
+            self.layer.graph,
+            dialect="duckdb",
+            preagg_schema=config.preagg_schema,
+        )
+
+    def run(self, query: dict[str, Any]) -> dict[str, Any]:
+        top_limit = ANALYTICS_BREAKDOWN_LIMIT
+        metric = metric_def(query.get("metric"))
+        dimension = dimension_def(query.get("dimension"), metric["model"])
+        granularity = granularity_for(query.get("granularity"))
+        events_filters = self._filters_for("events", query)
+        pageviews_filters = self._filters_for("pageviews", query)
+        sessions_filters = self._filters_for("sessions", query)
+        focus_filters = self._filters_for(metric["model"], query)
+        panel = clean(query.get("panel"))
+        if panel in CHART_PANELS:
+            return self._run_panel(
+                panel=panel,
+                query=query,
+                top_limit=top_limit,
+                metric=metric,
+                dimension=dimension,
+                granularity=granularity,
+                events_filters=events_filters,
+                pageviews_filters=pageviews_filters,
+                sessions_filters=sessions_filters,
+                focus_filters=focus_filters,
+            )
+
+        events_summary = self._one(
+            metrics=["events.event_count", "events.unique_users", "events.snapshot_events"],
+            filters=events_filters,
+            skip_default_time_dimensions=True,
+        )
+        pageviews_summary = self._one(
+            metrics=["pageviews.pageviews"],
+            filters=pageviews_filters,
+            skip_default_time_dimensions=True,
+        )
+        sessions_summary = self._one(
+            metrics=["sessions.session_count", "sessions.average_session_seconds"],
+            filters=sessions_filters,
+            skip_default_time_dimensions=True,
+        )
+        context_series_rows = self._rows(
+            metrics=[
+                "events.event_count",
+                "events.pageviews",
+                "events.unique_sessions",
+                "events.snapshot_events",
+            ],
+            dimensions=[f"events.event_time__{granularity}"],
+            filters=events_filters,
+            order_by=[f"events.event_time__{granularity}"],
+        )
+        focus_time_dimension = TIME_DIMENSIONS[metric["model"]]
+        focus_bucket_ref = f"{metric['model']}.{focus_time_dimension}__{granularity}"
+        focus_series_rows = self._rows(
+            metrics=[metric["ref"]],
+            dimensions=[focus_bucket_ref],
+            filters=focus_filters,
+            order_by=[focus_bucket_ref],
+        )
+        focus_total = self._one(
+            metrics=[metric["ref"]],
+            filters=focus_filters,
+            skip_default_time_dimensions=True,
+        )
+        focus_breakdown_filters = [
+            *self._filters_for(metric["model"], query, exclude_dimension_ref=dimension["ref"]),
+            f"{dimension['ref']} is not null",
+        ]
+        focus_breakdown_rows = self._rows(
+            metrics=[metric["ref"]],
+            dimensions=[dimension["ref"]],
+            filters=focus_breakdown_filters,
+            order_by=[f"{metric['ref']} DESC"],
+            limit=top_limit,
+            skip_default_time_dimensions=True,
+        )
+        focus_breakdown_total = self._metric_total(
+            metric["ref"],
+            metric["metric"],
+            focus_breakdown_filters,
+        )
+        top_events = self._rows(
+            metrics=["events.event_count"],
+            dimensions=["events.event_type"],
+            filters=[
+                *self._filters_for("events", query, exclude_dimension_ref="events.event_type"),
+                "events.event_type is not null",
+            ],
+            order_by=["events.event_count DESC"],
+            limit=top_limit,
+            skip_default_time_dimensions=True,
+        )
+        top_pages = self._rows(
+            metrics=["pageviews.pageviews"],
+            dimensions=["pageviews.pathname"],
+            filters=[
+                *self._filters_for("pageviews", query, exclude_dimension_ref="pageviews.pathname"),
+                "pageviews.pathname is not null",
+            ],
+            order_by=["pageviews.pageviews DESC"],
+            limit=top_limit,
+            skip_default_time_dimensions=True,
+        )
+        domains = self._rows(
+            metrics=["pageviews.pageviews"],
+            dimensions=["pageviews.host"],
+            filters=[
+                *self._filters_for("pageviews", query, exclude_dimension_ref="pageviews.host"),
+                "pageviews.host is not null",
+            ],
+            order_by=["pageviews.pageviews DESC"],
+            limit=top_limit,
+            skip_default_time_dimensions=True,
+        )
+        referring_domains = self._rows(
+            metrics=["pageviews.pageviews"],
+            dimensions=["pageviews.referrer_domain"],
+            filters=[
+                *self._filters_for("pageviews", query, exclude_dimension_ref="pageviews.referrer_domain"),
+                "pageviews.referrer_domain is not null",
+            ],
+            order_by=["pageviews.pageviews DESC"],
+            limit=top_limit,
+            skip_default_time_dimensions=True,
+        )
+        referrers = self._rows(
+            metrics=["pageviews.pageviews"],
+            dimensions=["pageviews.referrer"],
+            filters=[
+                *self._filters_for("pageviews", query, exclude_dimension_ref="pageviews.referrer"),
+                "pageviews.referrer is not null",
+            ],
+            order_by=["pageviews.pageviews DESC"],
+            limit=top_limit,
+            skip_default_time_dimensions=True,
+        )
+        browsers = self._rows(
+            metrics=["events.event_count"],
+            dimensions=["events.browser"],
+            filters=[
+                *self._filters_for("events", query, exclude_dimension_ref="events.browser"),
+                "events.browser is not null",
+            ],
+            order_by=["events.event_count DESC"],
+            limit=top_limit,
+            skip_default_time_dimensions=True,
+        )
+        countries = self._rows(
+            metrics=["events.event_count"],
+            dimensions=["events.geo_country_code"],
+            filters=[
+                *self._filters_for("events", query, exclude_dimension_ref="events.geo_country_code"),
+                "events.geo_country_code is not null",
+            ],
+            order_by=["events.event_count DESC"],
+            limit=top_limit,
+            skip_default_time_dimensions=True,
+        )
+        regions = self._rows(
+            metrics=["events.event_count"],
+            dimensions=["events.geo_region"],
+            filters=[
+                *self._filters_for("events", query, exclude_dimension_ref="events.geo_region"),
+                "events.geo_region is not null",
+            ],
+            order_by=["events.event_count DESC"],
+            limit=top_limit,
+            skip_default_time_dimensions=True,
+        )
+        cities = self._rows(
+            metrics=["events.event_count"],
+            dimensions=["events.geo_city"],
+            filters=[
+                *self._filters_for("events", query, exclude_dimension_ref="events.geo_city"),
+                "events.geo_city is not null",
+            ],
+            order_by=["events.event_count DESC"],
+            limit=top_limit,
+            skip_default_time_dimensions=True,
+        )
+
+        event_count = to_int(events_summary.get("event_count"))
+        pageviews = to_int(pageviews_summary.get("pageviews"))
+        unique_users = to_int(events_summary.get("unique_users"))
+        session_count = to_int(sessions_summary.get("session_count"))
+        average_session_seconds = to_float(sessions_summary.get("average_session_seconds"))
+        replay_chunks = to_int(events_summary.get("snapshot_events"))
+        focus_value = to_float(focus_total.get(metric["metric"]))
+
+        breakdowns = []
+        if not use_builtin_breakdown(dimension):
+            breakdowns.append(
+                breakdown(
+                    dimension.get("title", dimension["label"]),
+                    dimension["model"],
+                    dimension["dimension"],
+                    metric["ref"],
+                    focus_breakdown_rows,
+                    dimension["dimension"],
+                    metric["metric"],
+                    focus_breakdown_total,
+                )
+            )
+        for candidate in [
+            breakdown(
+                "Top events",
+                "events",
+                "event_type",
+                "events.event_count",
+                top_events,
+                "event_type",
+                "event_count",
+                event_count,
+            ),
+            breakdown(
+                "Top pages",
+                "pageviews",
+                "pathname",
+                "pageviews.pageviews",
+                top_pages,
+                "pathname",
+                "pageviews",
+                pageviews,
+            ),
+            breakdown(
+                "Domains",
+                "pageviews",
+                "host",
+                "pageviews.pageviews",
+                domains,
+                "host",
+                "pageviews",
+                pageviews,
+            ),
+            breakdown(
+                "Referring domains",
+                "pageviews",
+                "referrer_domain",
+                "pageviews.pageviews",
+                referring_domains,
+                "referrer_domain",
+                "pageviews",
+                pageviews,
+            ),
+            breakdown(
+                "Referrers",
+                "pageviews",
+                "referrer",
+                "pageviews.pageviews",
+                referrers,
+                "referrer",
+                "pageviews",
+                pageviews,
+            ),
+            breakdown(
+                "Browsers",
+                "events",
+                "browser",
+                "events.event_count",
+                browsers,
+                "browser",
+                "event_count",
+                event_count,
+            ),
+            breakdown(
+                "Countries",
+                "events",
+                "geo_country_code",
+                "events.event_count",
+                countries,
+                "geo_country_code",
+                "event_count",
+                event_count,
+            ),
+            breakdown(
+                "Regions",
+                "events",
+                "geo_region",
+                "events.event_count",
+                regions,
+                "geo_region",
+                "event_count",
+                event_count,
+            ),
+            breakdown(
+                "Cities",
+                "events",
+                "geo_city",
+                "events.event_count",
+                cities,
+                "geo_city",
+                "event_count",
+                event_count,
+            ),
+        ]:
+            if not any(same_breakdown(candidate, existing) for existing in breakdowns):
+                breakdowns.append(candidate)
+
+        return {
+            "focus": {
+                "metric": metric["ref"],
+                "metric_label": metric["label"],
+                "dimension": dimension["ref"],
+                "dimension_label": dimension["label"],
+                "granularity": granularity,
+            },
+            "summary": [
+                count_metric("Events", event_count, "events", "event_count"),
+                count_metric("Pageviews", pageviews, "pageviews", "pageviews"),
+                count_metric("Users", unique_users, "events", "unique_users"),
+                count_metric("SDK sessions", session_count, "sessions", "session_count"),
+                seconds_metric(
+                    "Avg session",
+                    average_session_seconds,
+                    "sessions",
+                    "average_session_seconds",
+                ),
+                count_metric("Replay chunks", replay_chunks, "events", "snapshot_events"),
+            ],
+            "series": series_points(
+                context_series_rows,
+                focus_series_rows,
+                focus_time_dimension,
+                granularity,
+                metric["metric"],
+            ),
+            "breakdowns": breakdowns,
+        }
+
+    def _run_panel(
+        self,
+        *,
+        panel: str,
+        query: dict[str, Any],
+        top_limit: int,
+        metric: dict[str, Any],
+        dimension: dict[str, Any],
+        granularity: str,
+        events_filters: list[str],
+        pageviews_filters: list[str],
+        sessions_filters: list[str],
+        focus_filters: list[str],
+    ) -> dict[str, Any]:
+        response = self._empty_response(metric, dimension, granularity)
+
+        if panel == "summary":
+            events_summary = self._one(
+                metrics=["events.event_count", "events.unique_users", "events.snapshot_events"],
+                filters=events_filters,
+                skip_default_time_dimensions=True,
+            )
+            pageviews_summary = self._one(
+                metrics=["pageviews.pageviews"],
+                filters=pageviews_filters,
+                skip_default_time_dimensions=True,
+            )
+            sessions_summary = self._one(
+                metrics=["sessions.session_count", "sessions.average_session_seconds"],
+                filters=sessions_filters,
+                skip_default_time_dimensions=True,
+            )
+            response["summary"] = [
+                count_metric("Events", to_int(events_summary.get("event_count")), "events", "event_count"),
+                count_metric("Pageviews", to_int(pageviews_summary.get("pageviews")), "pageviews", "pageviews"),
+                count_metric("Users", to_int(events_summary.get("unique_users")), "events", "unique_users"),
+                count_metric("SDK sessions", to_int(sessions_summary.get("session_count")), "sessions", "session_count"),
+                seconds_metric(
+                    "Avg session",
+                    to_float(sessions_summary.get("average_session_seconds")),
+                    "sessions",
+                    "average_session_seconds",
+                ),
+                count_metric("Replay chunks", to_int(events_summary.get("snapshot_events")), "events", "snapshot_events"),
+            ]
+            return response
+
+        if panel == "series":
+            context_series_rows = self._rows(
+                metrics=[
+                    "events.event_count",
+                    "events.pageviews",
+                    "events.unique_sessions",
+                    "events.snapshot_events",
+                ],
+                dimensions=[f"events.event_time__{granularity}"],
+                filters=events_filters,
+                order_by=[f"events.event_time__{granularity}"],
+            )
+            focus_time_dimension = TIME_DIMENSIONS[metric["model"]]
+            focus_bucket_ref = f"{metric['model']}.{focus_time_dimension}__{granularity}"
+            focus_series_rows = self._rows(
+                metrics=[metric["ref"]],
+                dimensions=[focus_bucket_ref],
+                filters=focus_filters,
+                order_by=[focus_bucket_ref],
+            )
+            response["series"] = series_points(
+                context_series_rows,
+                focus_series_rows,
+                focus_time_dimension,
+                granularity,
+                metric["metric"],
+            )
+            return response
+
+        if panel == "focus_breakdown":
+            if use_builtin_breakdown(dimension):
+                return response
+            focus_breakdown_filters = [
+                *self._filters_for(metric["model"], query, exclude_dimension_ref=dimension["ref"]),
+                f"{dimension['ref']} is not null",
+            ]
+            focus_breakdown_rows = self._rows(
+                metrics=[metric["ref"]],
+                dimensions=[dimension["ref"]],
+                filters=focus_breakdown_filters,
+                order_by=[f"{metric['ref']} DESC"],
+                limit=top_limit,
+                skip_default_time_dimensions=True,
+            )
+            focus_breakdown_total = self._metric_total(
+                metric["ref"],
+                metric["metric"],
+                focus_breakdown_filters,
+            )
+            response["breakdowns"] = [
+                breakdown(
+                    dimension.get("title", dimension["label"]),
+                    dimension["model"],
+                    dimension["dimension"],
+                    metric["ref"],
+                    focus_breakdown_rows,
+                    dimension["dimension"],
+                    metric["metric"],
+                    focus_breakdown_total,
+                )
+            ]
+            return response
+
+        leaderboard = self._leaderboard_panel(panel, query, top_limit)
+        if leaderboard:
+            response["breakdowns"] = [leaderboard]
+        return response
+
+    def _leaderboard_panel(
+        self,
+        panel: str,
+        query: dict[str, Any],
+        top_limit: int,
+    ) -> dict[str, Any] | None:
+        configs = {
+            "top_events": ("Top events", "events", "event_type", "events.event_count", "event_count"),
+            "top_pages": ("Top pages", "pageviews", "pathname", "pageviews.pageviews", "pageviews"),
+            "domains": ("Domains", "pageviews", "host", "pageviews.pageviews", "pageviews"),
+            "referring_domains": (
+                "Referring domains",
+                "pageviews",
+                "referrer_domain",
+                "pageviews.pageviews",
+                "pageviews",
+            ),
+            "referrers": ("Referrers", "pageviews", "referrer", "pageviews.pageviews", "pageviews"),
+            "browsers": ("Browsers", "events", "browser", "events.event_count", "event_count"),
+            "countries": ("Countries", "events", "geo_country_code", "events.event_count", "event_count"),
+            "regions": ("Regions", "events", "geo_region", "events.event_count", "event_count"),
+            "cities": ("Cities", "events", "geo_city", "events.event_count", "event_count"),
+        }
+        config = configs.get(panel)
+        if not config:
+            return None
+        title, model, dimension, metric_ref, value_key = config
+        dimension_ref = f"{model}.{dimension}"
+        filters = [
+            *self._filters_for(model, query, exclude_dimension_ref=dimension_ref),
+            f"{dimension_ref} is not null",
+        ]
+        rows = self._rows(
+            metrics=[metric_ref],
+            dimensions=[dimension_ref],
+            filters=filters,
+            order_by=[f"{metric_ref} DESC"],
+            limit=top_limit,
+            skip_default_time_dimensions=True,
+        )
+        total = self._metric_total(metric_ref, value_key, filters)
+        return breakdown(title, model, dimension, metric_ref, rows, dimension, value_key, total)
+
+    @staticmethod
+    def _empty_response(metric: dict[str, Any], dimension: dict[str, Any], granularity: str) -> dict[str, Any]:
+        return {
+            "focus": {
+                "metric": metric["ref"],
+                "metric_label": metric["label"],
+                "dimension": dimension["ref"],
+                "dimension_label": dimension["label"],
+                "granularity": granularity,
+            },
+            "summary": [],
+            "series": [],
+            "breakdowns": [],
+        }
+
+    def _connect_iceberg(self) -> None:
+        con = self.layer.adapter.raw_connection
+        con.execute("INSTALL httpfs")
+        con.execute("INSTALL iceberg")
+        con.execute("LOAD httpfs")
+        con.execute("LOAD iceberg")
+        con.execute("CREATE OR REPLACE SECRET r2_catalog_secret (TYPE ICEBERG, TOKEN ?)", [self.config.token])
+        con.execute(
+            f"ATTACH '{self.config.warehouse_name}' AS iceberg_catalog "
+            f"(TYPE ICEBERG, ENDPOINT '{self.config.catalog_endpoint}')"
+        )
+
+    def _bind_model_tables(self) -> None:
+        for model in self.layer.graph.models.values():
+            if model.sql:
+                model.sql = (
+                    model.sql.replace("{{ events_table }}", self.config.attached_events_table)
+                    .replace("{{ persons_table }}", self.config.attached_persons_table)
+                )
+
+    def _rows(
+        self,
+        *,
+        metrics: list[str],
+        dimensions: list[str] | None = None,
+        filters: list[str] | None = None,
+        order_by: list[str] | None = None,
+        limit: int | None = None,
+        skip_default_time_dimensions: bool = False,
+    ) -> list[dict[str, Any]]:
+        use_preaggregations = self.config.preagg_enabled
+        sql = self.generator.generate(
+            metrics=metrics,
+            dimensions=dimensions or [],
+            filters=filters or [],
+            order_by=order_by,
+            limit=limit,
+            skip_default_time_dimensions=skip_default_time_dimensions,
+            use_preaggregations=use_preaggregations,
+        )
+        try:
+            relation = self.layer.adapter.execute(sql)
+        except Exception:
+            if not use_preaggregations:
+                raise
+            fallback_sql = self.generator.generate(
+                metrics=metrics,
+                dimensions=dimensions or [],
+                filters=filters or [],
+                order_by=order_by,
+                limit=limit,
+                skip_default_time_dimensions=skip_default_time_dimensions,
+                use_preaggregations=False,
+            )
+            relation = self.layer.adapter.execute(fallback_sql)
+        columns = [column[0] for column in relation.description]
+        return [dict(zip(columns, row, strict=False)) for row in relation.fetchall()]
+
+    def _materialize_preaggregations(self) -> None:
+        if not self.config.preagg_enabled:
+            return
+        con = self.layer.adapter.raw_connection
+        con.execute(f"CREATE SCHEMA IF NOT EXISTS {self.config.preagg_schema}")
+        for model_name, model in self.layer.graph.models.items():
+            for preagg in model.pre_aggregations:
+                table_name = preagg.get_table_name(model_name, schema=self.config.preagg_schema)
+                source_sql = preagg.generate_materialization_sql(model)
+                started = time.perf_counter()
+                print(
+                    f"sidemantic preagg refresh start {model_name}.{preagg.name} -> {table_name}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                result = preagg.refresh(
+                    connection=con,
+                    source_sql=source_sql,
+                    table_name=table_name,
+                    mode="full",
+                )
+                con.execute(f"ANALYZE {table_name}")
+                elapsed = time.perf_counter() - started
+                print(
+                    "sidemantic preagg refresh done "
+                    f"{model_name}.{preagg.name} rows={result.rows_inserted} "
+                    f"seconds={elapsed:.2f}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+    def _one(self, **kwargs: Any) -> dict[str, Any]:
+        rows = self._rows(**kwargs)
+        return rows[0] if rows else {}
+
+    def _metric_total(self, metric_ref: str, value_key: str, filters: list[str]) -> float:
+        return to_float(
+            self._one(
+                metrics=[metric_ref],
+                filters=filters,
+                skip_default_time_dimensions=True,
+            ).get(value_key)
+        )
+
+    def _filters_for(
+        self,
+        model: str,
+        query: dict[str, Any],
+        *,
+        exclude_dimension_ref: str | None = None,
+    ) -> list[str]:
+        fields = {
+            "events": {
+                "distinct_id": "distinct_id",
+                "session_id": "session_id",
+                "event_name": "event_type",
+                "url": "current_url",
+                "time": "event_time",
+            },
+            "pageviews": {
+                "distinct_id": "actor_id",
+                "session_id": "session_id",
+                "event_name": "event_type",
+                "url": "current_url",
+                "time": "event_time",
+            },
+            "sessions": {
+                "distinct_id": "actor_id",
+                "session_id": "session_id",
+                "url": "landing_url",
+                "time": "session_start_at",
+            },
+        }[model]
+        filters: list[str] = []
+
+        for query_key in ("distinct_id", "session_id", "event_name"):
+            value = clean(query.get(query_key))
+            field = fields.get(query_key)
+            if value and field:
+                filters.append(f"{model}.{field} = {sql_string(value)}")
+
+        url = clean(query.get("url"))
+        if url and fields.get("url"):
+            needle = sql_like(url.lower())
+            if model == "sessions":
+                filters.append(
+                    f"(lower({model}.landing_url) like {needle} or lower({model}.exit_url) like {needle})"
+                )
+            else:
+                filters.append(f"lower({model}.{fields['url']}) like {needle}")
+
+        date_from = clean(query.get("date_from"))
+        if date_from:
+            filters.append(f"{model}.{fields['time']} >= {sql_string(date_from)}")
+        date_to = clean(query.get("date_to"))
+        if date_to:
+            filters.append(f"{model}.{fields['time']} <= {sql_string(date_to)}")
+
+        filters.extend(semantic_filters_for(model, query, exclude_dimension_ref=exclude_dimension_ref))
+        return filters
+
+
+def metric_def(value: Any) -> dict[str, Any]:
+    ref = clean(value) or "events.event_count"
+    if ref not in METRICS:
+        ref = "events.event_count"
+    metric = dict(METRICS[ref])
+    metric["ref"] = ref
+    return metric
+
+
+def dimension_def(value: Any, model: str) -> dict[str, Any]:
+    ref = clean(value) or DEFAULT_DIMENSIONS[model]
+    if ref not in DIMENSIONS or DIMENSIONS[ref]["model"] != model:
+        ref = DEFAULT_DIMENSIONS[model]
+    dimension = dict(DIMENSIONS[ref])
+    dimension["ref"] = ref
+    return dimension
+
+
+def granularity_for(value: Any) -> str:
+    granularity = clean(value) or "day"
+    return granularity if granularity in GRANULARITIES else "day"
+
+
+def semantic_filters_for(
+    model: str,
+    query: dict[str, Any],
+    *,
+    exclude_dimension_ref: str | None = None,
+) -> list[str]:
+    filters: list[str] = []
+    for source_ref, values in semantic_filters_from_query(query).items():
+        if source_ref == exclude_dimension_ref:
+            continue
+        target_ref = dimension_ref_for_model(source_ref, model)
+        if not target_ref:
+            continue
+        if target_ref == exclude_dimension_ref:
+            continue
+        target = DIMENSIONS[target_ref]
+        sql_values = []
+        for value in values:
+            sql_value = value_sql(target, value)
+            if sql_value is not None:
+                sql_values.append(sql_value)
+        if not sql_values:
+            continue
+        if len(sql_values) == 1:
+            filters.append(f"{target_ref} = {sql_values[0]}")
+        else:
+            filters.append(f"{target_ref} in ({', '.join(sql_values)})")
+    return filters
+
+
+def semantic_filters_from_query(query: dict[str, Any]) -> dict[str, list[str]]:
+    raw = clean(query.get("semantic_filters"))
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+
+    filters: dict[str, list[str]] = {}
+    for ref, values in parsed.items():
+        ref = clean(ref)
+        if ref not in DIMENSIONS:
+            continue
+        value_list = values if isinstance(values, list) else [values]
+        cleaned = [value for value in (clean(value) for value in value_list) if value is not None]
+        if cleaned:
+            filters[ref] = cleaned[:20]
+    return filters
+
+
+def dimension_ref_for_model(source_ref: str, model: str) -> str | None:
+    source = DIMENSIONS.get(source_ref)
+    if not source:
+        return None
+    if source["model"] == model:
+        return source_ref
+    source_dimension = source["dimension"]
+    for ref, candidate in DIMENSIONS.items():
+        if candidate["model"] == model and candidate["dimension"] == source_dimension:
+            return ref
+    return None
+
+
+def series_points(
+    context_rows: list[dict[str, Any]],
+    focus_rows: list[dict[str, Any]],
+    focus_time_dimension: str,
+    granularity: str,
+    focus_value_key: str,
+) -> list[dict[str, Any]]:
+    context_bucket_key = f"event_time__{granularity}"
+    focus_bucket_key = f"{focus_time_dimension}__{granularity}"
+    context_by_bucket = {
+        date_label(row.get(context_bucket_key)): row
+        for row in context_rows
+        if row.get(context_bucket_key) is not None
+    }
+    focus_by_bucket = {
+        date_label(row.get(focus_bucket_key)): row
+        for row in focus_rows
+        if row.get(focus_bucket_key) is not None
+    }
+    buckets = sorted(set(context_by_bucket) | set(focus_by_bucket))
+    return [
+        {
+            "bucket": bucket,
+            "event_count": to_int(context_by_bucket.get(bucket, {}).get("event_count")),
+            "pageviews": to_int(context_by_bucket.get(bucket, {}).get("pageviews")),
+            "session_count": to_int(context_by_bucket.get(bucket, {}).get("unique_sessions")),
+            "recordings": to_int(context_by_bucket.get(bucket, {}).get("snapshot_events")),
+            "focused_value": to_float(focus_by_bucket.get(bucket, {}).get(focus_value_key)),
+        }
+        for bucket in buckets
+    ]
+
+
+def same_breakdown(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    return (
+        left.get("model") == right.get("model")
+        and left.get("dimension") == right.get("dimension")
+        and left.get("metric") == right.get("metric")
+    )
+
+
+def use_geo_hierarchy_breakdown(dimension: dict[str, Any]) -> bool:
+    return dimension.get("dimension") in {"geo_country_code", "geo_region", "geo_city"}
+
+
+def use_builtin_breakdown(dimension: dict[str, Any]) -> bool:
+    return dimension.get("ref") in BUILTIN_BREAKDOWN_DIMENSIONS or use_geo_hierarchy_breakdown(dimension)
+
+
+def breakdown(
+    title: str,
+    model: str,
+    dimension: str,
+    metric: str,
+    rows: list[dict[str, Any]],
+    label_key: str,
+    value_key: str,
+    total: float,
+    *,
+    denominator: str = "max",
+) -> dict[str, Any]:
+    row_values = [
+        (str(row.get(label_key)), to_float(row.get(value_key)))
+        for row in rows
+        if row.get(label_key) is not None
+    ]
+    values = [value for _, value in row_values]
+    percent_base = max(values, default=0.0) if denominator == "max" else total
+    payload_rows = [
+        {
+            "label": label,
+            "value": value,
+            "percent": percent(value, percent_base),
+        }
+        for label, value in row_values
+    ]
+    other_value = max(0.0, total - sum(values))
+    if other_value > 0.0001:
+        payload_rows.append(
+            {
+                "label": "Others",
+                "value": other_value,
+                "percent": percent(other_value, percent_base),
+                "is_other": True,
+            }
+        )
+    return {
+        "title": title,
+        "model": model,
+        "dimension": dimension,
+        "metric": metric,
+        "rows": payload_rows,
+    }
+
+
+def count_metric(label: str, value: int, model: str, metric: str) -> dict[str, Any]:
+    return {
+        "label": label,
+        "value": float(value),
+        "display_value": format_count(value),
+        "model": model,
+        "metric": metric,
+        "semantic_ref": f"{model}.{metric}",
+    }
+
+
+def seconds_metric(label: str, value: float, model: str, metric: str) -> dict[str, Any]:
+    return {
+        "label": label,
+        "value": value,
+        "display_value": f"{value:.1f}s",
+        "model": model,
+        "metric": metric,
+        "semantic_ref": f"{model}.{metric}",
+    }
+
+
+def infer_persons_table(events_table: str) -> str:
+    replacements = [
+        ("hogflare_events_v3", "hogflare_persons_v2"),
+        ("hogflare_events", "hogflare_persons"),
+        ("events", "persons"),
+    ]
+    for needle, replacement in replacements:
+        if needle in events_table:
+            return events_table.replace(needle, replacement)
+    return "default.hogflare_persons_v2"
+
+
+def clean(value: Any) -> str | None:
+    if value is None:
+        return None
+    value = str(value).strip()
+    return value or None
+
+
+def sql_string(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def value_sql(dimension: dict[str, Any], value: str) -> str | None:
+    normalized = clean(value)
+    if normalized is None:
+        return None
+    if dimension.get("type") == "numeric":
+        return normalized if NUMERIC_LITERAL_RE.match(normalized) else None
+    return sql_string(normalized)
+
+
+def sql_like(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_").replace("'", "''")
+    return f"'%{escaped}%'"
+
+
+def to_int(value: Any) -> int:
+    return int(value or 0)
+
+
+def to_float(value: Any) -> float:
+    return float(value or 0)
+
+
+def percent(value: float, total: float) -> float:
+    return 0.0 if total == 0 else (value / total) * 100.0
+
+
+def format_count(value: int) -> str:
+    return f"{value:,}"
+
+
+def date_label(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return str(value)
+
+
+def clamp_int(value: Any, *, default: int, low: int, high: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return min(high, max(low, parsed))
+
+
+def env_required(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def env_required_any(*names: str) -> str:
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    raise RuntimeError(f"{names[0]} is required")
+
+
+def env_flag(name: str, *, default: bool) -> bool:
+    value = clean(os.environ.get(name))
+    if value is None:
+        return default
+    return value.lower() not in {"0", "false", "no", "off"}
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/product_analytics_sidemantic.py
+++ b/scripts/product_analytics_sidemantic.py
@@ -531,17 +531,6 @@ class SidemanticAnalytics:
             filters=sessions_filters,
             skip_default_time_dimensions=True,
         )
-        context_series_rows = self._rows(
-            metrics=[
-                "events.event_count",
-                "events.pageviews",
-                "events.unique_sessions",
-                "events.snapshot_events",
-            ],
-            dimensions=[f"events.event_time__{granularity}"],
-            filters=events_filters,
-            order_by=[f"events.event_time__{granularity}"],
-        )
         focus_time_dimension = TIME_DIMENSIONS[metric["model"]]
         focus_bucket_ref = f"{metric['model']}.{focus_time_dimension}__{granularity}"
         focus_series_rows = self._rows(
@@ -680,23 +669,21 @@ class SidemanticAnalytics:
         replay_chunks = to_int(events_summary.get("snapshot_events"))
         focus_value = to_float(focus_total.get(metric["metric"]))
 
-        breakdowns = []
-        if not use_builtin_breakdown(dimension):
-            breakdowns.append(
-                breakdown(
-                    dimension.get("title", dimension["label"]),
-                    dimension["model"],
-                    dimension["dimension"],
-                    metric["ref"],
-                    focus_breakdown_rows,
-                    dimension["dimension"],
-                    metric["metric"],
-                    focus_breakdown_total,
-                )
+        breakdowns = [
+            breakdown(
+                f"{metric['label']} by {dimension['label']}",
+                dimension["model"],
+                dimension["dimension"],
+                metric["ref"],
+                focus_breakdown_rows,
+                dimension["dimension"],
+                metric["metric"],
+                focus_breakdown_total,
             )
+        ]
         for candidate in [
             breakdown(
-                "Top events",
+                "Events by Event",
                 "events",
                 "event_type",
                 "events.event_count",
@@ -706,7 +693,7 @@ class SidemanticAnalytics:
                 event_count,
             ),
             breakdown(
-                "Top pages",
+                "Pageviews by Page",
                 "pageviews",
                 "pathname",
                 "pageviews.pageviews",
@@ -716,7 +703,7 @@ class SidemanticAnalytics:
                 pageviews,
             ),
             breakdown(
-                "Domains",
+                "Pageviews by Domain",
                 "pageviews",
                 "host",
                 "pageviews.pageviews",
@@ -726,7 +713,7 @@ class SidemanticAnalytics:
                 pageviews,
             ),
             breakdown(
-                "Referring domains",
+                "Pageviews by Referring domain",
                 "pageviews",
                 "referrer_domain",
                 "pageviews.pageviews",
@@ -736,7 +723,7 @@ class SidemanticAnalytics:
                 pageviews,
             ),
             breakdown(
-                "Referrers",
+                "Pageviews by Referrer",
                 "pageviews",
                 "referrer",
                 "pageviews.pageviews",
@@ -746,7 +733,7 @@ class SidemanticAnalytics:
                 pageviews,
             ),
             breakdown(
-                "Browsers",
+                "Events by Browser",
                 "events",
                 "browser",
                 "events.event_count",
@@ -756,7 +743,7 @@ class SidemanticAnalytics:
                 event_count,
             ),
             breakdown(
-                "Countries",
+                "Events by Country",
                 "events",
                 "geo_country_code",
                 "events.event_count",
@@ -766,7 +753,7 @@ class SidemanticAnalytics:
                 event_count,
             ),
             breakdown(
-                "Regions",
+                "Events by Region",
                 "events",
                 "geo_region",
                 "events.event_count",
@@ -776,7 +763,7 @@ class SidemanticAnalytics:
                 event_count,
             ),
             breakdown(
-                "Cities",
+                "Events by City",
                 "events",
                 "geo_city",
                 "events.event_count",
@@ -811,7 +798,6 @@ class SidemanticAnalytics:
                 count_metric("Replay chunks", replay_chunks, "events", "snapshot_events"),
             ],
             "series": series_points(
-                context_series_rows,
                 focus_series_rows,
                 focus_time_dimension,
                 granularity,
@@ -868,17 +854,6 @@ class SidemanticAnalytics:
             return response
 
         if panel == "series":
-            context_series_rows = self._rows(
-                metrics=[
-                    "events.event_count",
-                    "events.pageviews",
-                    "events.unique_sessions",
-                    "events.snapshot_events",
-                ],
-                dimensions=[f"events.event_time__{granularity}"],
-                filters=events_filters,
-                order_by=[f"events.event_time__{granularity}"],
-            )
             focus_time_dimension = TIME_DIMENSIONS[metric["model"]]
             focus_bucket_ref = f"{metric['model']}.{focus_time_dimension}__{granularity}"
             focus_series_rows = self._rows(
@@ -888,7 +863,6 @@ class SidemanticAnalytics:
                 order_by=[focus_bucket_ref],
             )
             response["series"] = series_points(
-                context_series_rows,
                 focus_series_rows,
                 focus_time_dimension,
                 granularity,
@@ -897,8 +871,6 @@ class SidemanticAnalytics:
             return response
 
         if panel == "focus_breakdown":
-            if use_builtin_breakdown(dimension):
-                return response
             focus_breakdown_filters = [
                 *self._filters_for(metric["model"], query, exclude_dimension_ref=dimension["ref"]),
                 f"{dimension['ref']} is not null",
@@ -918,7 +890,7 @@ class SidemanticAnalytics:
             )
             response["breakdowns"] = [
                 breakdown(
-                    dimension.get("title", dimension["label"]),
+                    f"{metric['label']} by {dimension['label']}",
                     dimension["model"],
                     dimension["dimension"],
                     metric["ref"],
@@ -942,21 +914,21 @@ class SidemanticAnalytics:
         top_limit: int,
     ) -> dict[str, Any] | None:
         configs = {
-            "top_events": ("Top events", "events", "event_type", "events.event_count", "event_count"),
-            "top_pages": ("Top pages", "pageviews", "pathname", "pageviews.pageviews", "pageviews"),
-            "domains": ("Domains", "pageviews", "host", "pageviews.pageviews", "pageviews"),
+            "top_events": ("Events by Event", "events", "event_type", "events.event_count", "event_count"),
+            "top_pages": ("Pageviews by Page", "pageviews", "pathname", "pageviews.pageviews", "pageviews"),
+            "domains": ("Pageviews by Domain", "pageviews", "host", "pageviews.pageviews", "pageviews"),
             "referring_domains": (
-                "Referring domains",
+                "Pageviews by Referring domain",
                 "pageviews",
                 "referrer_domain",
                 "pageviews.pageviews",
                 "pageviews",
             ),
-            "referrers": ("Referrers", "pageviews", "referrer", "pageviews.pageviews", "pageviews"),
-            "browsers": ("Browsers", "events", "browser", "events.event_count", "event_count"),
-            "countries": ("Countries", "events", "geo_country_code", "events.event_count", "event_count"),
-            "regions": ("Regions", "events", "geo_region", "events.event_count", "event_count"),
-            "cities": ("Cities", "events", "geo_city", "events.event_count", "event_count"),
+            "referrers": ("Pageviews by Referrer", "pageviews", "referrer", "pageviews.pageviews", "pageviews"),
+            "browsers": ("Events by Browser", "events", "browser", "events.event_count", "event_count"),
+            "countries": ("Events by Country", "events", "geo_country_code", "events.event_count", "event_count"),
+            "regions": ("Events by Region", "events", "geo_region", "events.event_count", "event_count"),
+            "cities": ("Events by City", "events", "geo_city", "events.event_count", "event_count"),
         }
         config = configs.get(panel)
         if not config:
@@ -1243,32 +1215,25 @@ def dimension_ref_for_model(source_ref: str, model: str) -> str | None:
 
 
 def series_points(
-    context_rows: list[dict[str, Any]],
     focus_rows: list[dict[str, Any]],
     focus_time_dimension: str,
     granularity: str,
     focus_value_key: str,
 ) -> list[dict[str, Any]]:
-    context_bucket_key = f"event_time__{granularity}"
     focus_bucket_key = f"{focus_time_dimension}__{granularity}"
-    context_by_bucket = {
-        date_label(row.get(context_bucket_key)): row
-        for row in context_rows
-        if row.get(context_bucket_key) is not None
-    }
     focus_by_bucket = {
         date_label(row.get(focus_bucket_key)): row
         for row in focus_rows
         if row.get(focus_bucket_key) is not None
     }
-    buckets = sorted(set(context_by_bucket) | set(focus_by_bucket))
+    buckets = sorted(focus_by_bucket)
     return [
         {
             "bucket": bucket,
-            "event_count": to_int(context_by_bucket.get(bucket, {}).get("event_count")),
-            "pageviews": to_int(context_by_bucket.get(bucket, {}).get("pageviews")),
-            "session_count": to_int(context_by_bucket.get(bucket, {}).get("unique_sessions")),
-            "recordings": to_int(context_by_bucket.get(bucket, {}).get("snapshot_events")),
+            "event_count": 0,
+            "pageviews": 0,
+            "session_count": 0,
+            "recordings": 0,
             "focused_value": to_float(focus_by_bucket.get(bucket, {}).get(focus_value_key)),
         }
         for bucket in buckets

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -157,17 +157,23 @@
         border-bottom: 0;
       }
 
+      .app.analytics-mode .status {
+        display: none !important;
+      }
+
       .app.analytics-mode .rail-body,
       .app.analytics-mode .rail-dock {
         display: none;
       }
 
-      .app.analytics-mode .stage-head {
-        padding-left: calc(var(--analytics-nav-width) + 16px);
-      }
-
       .app.analytics-mode .stage {
         grid-column: 1 / -1;
+        grid-template-rows: auto minmax(0, 1fr);
+      }
+
+      .app.analytics-mode .stage-title,
+      .app.analytics-mode .stage-head .actions {
+        display: none;
       }
 
       .topbar,
@@ -1560,11 +1566,6 @@
           border-right: 0;
         }
 
-        .app.analytics-mode .stage-head {
-          height: auto;
-          padding: 64px 16px 8px;
-        }
-
         .filters {
           grid-template-columns: 1fr;
         }
@@ -1686,7 +1687,7 @@
                   <label class="label" for="metric">Metric</label>
                   <select id="metric" name="metric">
                     <optgroup label="Events">
-                      <option value="events.event_count">Events</option>
+                      <option value="events.capture_events">Events</option>
                       <option value="events.unique_users">Users</option>
                     </optgroup>
                     <optgroup label="Pageviews">
@@ -2035,6 +2036,7 @@
         playerResizeTimer: null,
         chartResizeTimer: null,
         analyticsRequestId: 0,
+        analyticsAbortController: null,
         analyticsLoading: false,
         analyticsPendingPanels: new Set(),
         railCollapsed: false,
@@ -2054,11 +2056,14 @@
       };
 
       const analyticsMetricModels = {
-        "events.event_count": "events",
+        "events.capture_events": "events",
         "events.unique_users": "events",
         "pageviews.pageviews": "pageviews",
         "sessions.session_count": "sessions",
         "sessions.average_session_seconds": "sessions",
+      };
+      const analyticsMetricAliases = {
+        "events.event_count": "events.capture_events",
       };
 
       const analyticsDefaultDimensions = {
@@ -2264,6 +2269,7 @@
       function setField(name, value) {
         const input = els.filters.elements.namedItem(name);
         if (!input || !value) return;
+        if (name === "metric") value = normalizeAnalyticsMetricRef(value);
         input.value = input.type === "datetime-local" ? isoToDateInput(value) : value;
       }
 
@@ -2886,12 +2892,21 @@
 
       function cancelAnalyticsRequests() {
         state.analyticsRequestId += 1;
+        if (state.analyticsAbortController) {
+          state.analyticsAbortController.abort();
+          state.analyticsAbortController = null;
+        }
         state.analyticsPendingPanels.clear();
         setAnalyticsLoading(false);
       }
 
       async function loadCharts(options = {}) {
         const requestId = ++state.analyticsRequestId;
+        if (state.analyticsAbortController) {
+          state.analyticsAbortController.abort();
+        }
+        const controller = new AbortController();
+        state.analyticsAbortController = controller;
         const params = paramsFromForm({ mode: "overview" });
         const availablePanels = analyticsPanelsForCurrentQuery();
         const panels = analyticsPanelsForRequest(options.panels, availablePanels);
@@ -2908,26 +2923,27 @@
           renderChartContext();
           replaceUrl(analyticsPath, params);
           let failures = 0;
-          await Promise.all(
-            panels.map(async (panel) => {
-              const panelParams = new URLSearchParams(params);
-              panelParams.set("panel", panel);
-              try {
-                const body = await requestJson("/analytics/api/charts", panelParams);
-                if (requestId !== state.analyticsRequestId) return;
-                mergeAnalyticsPanel(panel, body);
-              } catch (error) {
-                if (error?.name === "AbortError" || requestId !== state.analyticsRequestId) return;
-                failures += 1;
-              } finally {
-                if (requestId === state.analyticsRequestId) {
-                  state.analyticsPendingPanels.delete(panel);
-                  renderCharts(state.charts);
-                  renderChartContext();
-                }
+          for (const panel of panels) {
+            if (controller.signal.aborted || requestId !== state.analyticsRequestId) return;
+            const panelParams = new URLSearchParams(params);
+            panelParams.set("panel", panel);
+            try {
+              const body = await requestJson("/analytics/api/charts", panelParams, {
+                signal: controller.signal,
+              });
+              if (requestId !== state.analyticsRequestId) return;
+              mergeAnalyticsPanel(panel, body);
+            } catch (error) {
+              if (error?.name === "AbortError" || requestId !== state.analyticsRequestId) return;
+              failures += 1;
+            } finally {
+              if (requestId === state.analyticsRequestId) {
+                state.analyticsPendingPanels.delete(panel);
+                renderCharts(state.charts);
+                renderChartContext();
               }
-            }),
-          );
+            }
+          }
           if (requestId !== state.analyticsRequestId) return;
           if (failures === panels.length) throw new Error("Analytics panels failed to load.");
           if (failures) setStatus(`${failures} analytics panels failed`);
@@ -2935,6 +2951,9 @@
         } finally {
           if (requestId === state.analyticsRequestId) {
             setAnalyticsLoading(false);
+            if (state.analyticsAbortController === controller) {
+              state.analyticsAbortController = null;
+            }
             state.analyticsPendingPanels.clear();
             renderAnalyticsFacts(state.charts);
             renderChartContext();
@@ -3508,10 +3527,11 @@
       }
 
       function selectAnalyticsMetric(metricRef) {
+        metricRef = normalizeAnalyticsMetricRef(metricRef);
         if (!analyticsMetricModels[metricRef]) return;
         els.metric.value = metricRef;
         syncAnalyticsDimensions();
-        if (state.mode === "overview") requestAnalyticsSearch({ panels: analyticsFocusPanels() });
+        if (state.mode === "overview") requestAnalyticsSearch();
       }
 
       function renderSeriesPanel(charts) {
@@ -3783,7 +3803,7 @@
             label: charts?.focus?.metric_label || "Selected",
             color: "#087a55",
           },
-          { key: "event_count", ref: "events.event_count", label: "Events", color: "#5c6670" },
+          { key: "event_count", ref: "events.capture_events", label: "Events", color: "#5c6670" },
           { key: "pageviews", ref: "pageviews.pageviews", label: "Pageviews", color: "#2d5f9a" },
           { key: "session_count", ref: "events.unique_sessions", label: "Sessions", color: "#9a6b16" },
           { key: "recordings", ref: "events.snapshot_events", label: "Recordings", color: "#9d332b" },
@@ -3802,21 +3822,23 @@
         return new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(value || 0);
       }
 
+      function normalizeAnalyticsMetricRef(metricRef) {
+        return analyticsMetricAliases[metricRef] || metricRef;
+      }
+
       function analyticsFocusFromCurrentForm() {
-        const metric = analyticsMetricModels[els.metric.value] ? els.metric.value : "events.event_count";
+        const metric = normalizeAnalyticsMetricRef(els.metric.value);
         return {
-          metric,
+          metric: analyticsMetricModels[metric] ? metric : "events.capture_events",
           dimension: els.dimension.value || "events.event_type",
           granularity: els.granularity.value || "day",
         };
       }
 
       function analyticsFocusFromParams(params) {
-        const metric = analyticsMetricModels[params.get("metric")]
-          ? params.get("metric")
-          : els.metric.value || "events.event_count";
+        const metric = normalizeAnalyticsMetricRef(params.get("metric") || els.metric.value);
         return {
-          metric,
+          metric: analyticsMetricModels[metric] ? metric : "events.capture_events",
           dimension: params.get("dimension") || els.dimension.value || "events.event_type",
           granularity: params.get("granularity") || els.granularity.value || "day",
         };
@@ -4419,7 +4441,7 @@
           params.get("section") === "analytics";
         const bootingReplay = location.pathname.replace(/\/$/, "") === replayPath;
         const metricParam = params.get("metric");
-        if (bootingAnalytics && metricParam && !analyticsMetricModels[metricParam]) {
+        if (bootingAnalytics && metricParam && !analyticsMetricModels[normalizeAnalyticsMetricRef(metricParam)]) {
           setMode("overview");
           setStatus("error");
           showMessage("error", "Analytics unavailable", `Unsupported analytics metric: ${metricParam}`);

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -1048,14 +1048,22 @@
       }
 
       .breakdown-grid .chart-panel {
-        border-left: 1px solid var(--line);
+        border-top: 1px solid var(--line);
         border-bottom: 0;
         background: var(--surface);
       }
 
       .breakdown-grid .chart-panel:first-child {
         grid-column: span 2;
-        border-left: 0;
+      }
+
+      .breakdown-grid .chart-panel:nth-child(2),
+      .breakdown-grid .chart-panel:nth-child(4),
+      .breakdown-grid .chart-panel:nth-child(5),
+      .breakdown-grid .chart-panel:nth-child(7),
+      .breakdown-grid .chart-panel:nth-child(8),
+      .breakdown-grid .chart-panel:nth-child(10) {
+        border-left: 1px solid var(--line);
       }
 
       .breakdown-row {
@@ -1332,6 +1340,15 @@
 
         .breakdown-grid .chart-panel:first-child {
           grid-column: span 1;
+        }
+
+        .breakdown-grid .chart-panel:nth-child(2),
+        .breakdown-grid .chart-panel:nth-child(4),
+        .breakdown-grid .chart-panel:nth-child(5),
+        .breakdown-grid .chart-panel:nth-child(7),
+        .breakdown-grid .chart-panel:nth-child(8),
+        .breakdown-grid .chart-panel:nth-child(10) {
+          border-left: 0;
         }
       }
     </style>

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -989,7 +989,7 @@
         display: grid;
         align-content: start;
         gap: 0;
-        padding: 4px 0 12px;
+        padding: 4px 0 0;
       }
 
       .skeleton-line,
@@ -1048,7 +1048,7 @@
       .breakdown-grid .chart-panel {
         border-bottom: 0;
         background: var(--surface);
-        overflow: visible;
+        overflow: hidden;
       }
 
       .breakdown-grid .chart-panel:first-child {
@@ -1140,6 +1140,7 @@
       .breakdown-value {
         position: relative;
         z-index: 1;
+        min-width: max-content;
         color: var(--muted);
         font-family: var(--mono);
         font-size: 11px;
@@ -3245,14 +3246,19 @@
 
       function seriesConfig(charts = null) {
         const focusMetric = charts?.focus?.metric || "";
-        return [
+        const config = [
           {
             key: "focused_value",
             ref: focusMetric,
             label: charts?.focus?.metric_label || "Selected",
             color: "#087a55",
           },
+          { key: "event_count", ref: "events.event_count", label: "Events", color: "#5c6670" },
+          { key: "pageviews", ref: "pageviews.pageviews", label: "Pageviews", color: "#2d5f9a" },
+          { key: "session_count", ref: "events.unique_sessions", label: "Sessions", color: "#9a6b16" },
+          { key: "recordings", ref: "events.snapshot_events", label: "Recordings", color: "#9d332b" },
         ];
+        return config.filter((item, index) => index === 0 || item.ref !== focusMetric);
       }
 
       function grainLabel(granularity) {

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -77,6 +77,7 @@
       .stage,
       .inspector {
         min-height: 0;
+        min-width: 0;
         background: var(--surface);
       }
 
@@ -95,6 +96,7 @@
 
       .stage {
         display: grid;
+        grid-template-columns: minmax(0, 1fr);
         grid-template-rows: auto minmax(0, 1fr);
         border-right: 1px solid var(--line);
       }
@@ -144,10 +146,19 @@
       .topbar {
         display: flex;
         align-items: center;
+        gap: 12px;
         justify-content: space-between;
       }
 
+      .topbar-primary {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+        gap: 12px;
+      }
+
       .brand-mark {
+        flex: 0 0 auto;
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -210,8 +221,47 @@
         background: var(--accent);
       }
 
+      .status.is-loading::before {
+        width: 8px;
+        height: 8px;
+        border: 2px solid var(--line-strong);
+        border-top-color: var(--accent);
+        background: transparent;
+        animation: spin 700ms linear infinite;
+      }
+
       .status[hidden] {
         display: none !important;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .section-switch {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+        gap: 2px;
+      }
+
+      .section-button {
+        height: 28px;
+        border: 0;
+        border-radius: 999px;
+        background: transparent;
+        color: var(--muted);
+        padding: 0 10px;
+        font-size: 12px;
+        font-weight: 720;
+        white-space: nowrap;
+      }
+
+      .section-button[aria-selected="true"] {
+        background: var(--ink);
+        color: var(--surface);
       }
 
       .mode-switch {
@@ -269,6 +319,62 @@
       .mode-panel {
         display: grid;
         gap: 8px;
+      }
+
+      .section-controls {
+        display: grid;
+        grid-column: 1 / -1;
+        gap: 10px;
+      }
+
+      .analytics-query-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
+        gap: 10px;
+      }
+
+      .semantic-filter-strip {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 6px;
+        border-top: 1px solid var(--line);
+        padding-top: 8px;
+      }
+
+      .semantic-filter-pill {
+        display: inline-flex;
+        align-items: center;
+        max-width: 100%;
+        gap: 5px;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        background: var(--surface);
+        color: var(--muted);
+        font-size: 11px;
+        line-height: 1;
+        padding: 5px 6px 5px 8px;
+      }
+
+      .semantic-filter-pill span {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .semantic-filter-pill button {
+        display: grid;
+        place-items: center;
+        width: 16px;
+        height: 16px;
+        border: 0;
+        border-radius: 999px;
+        background: var(--surface-soft);
+        color: var(--muted);
+        cursor: pointer;
+        font: inherit;
+        padding: 0;
       }
 
       .select-row {
@@ -368,6 +474,12 @@
         font-weight: 680;
       }
 
+      .preset-button.is-selected {
+        border-color: var(--accent);
+        background: var(--accent-soft);
+        color: var(--ink);
+      }
+
       .field {
         display: grid;
         min-width: 0;
@@ -379,6 +491,7 @@
       }
 
       .field input,
+      .field select,
       .date-field input {
         width: 100%;
         height: 34px;
@@ -392,6 +505,10 @@
         font-size: 12px;
       }
 
+      .field select {
+        cursor: pointer;
+      }
+
       .date-field input {
         padding-right: 6px;
       }
@@ -402,6 +519,7 @@
       }
 
       .field input:focus,
+      .field select:focus,
       .date-field input:focus {
         border-color: var(--accent);
         box-shadow: 0 0 0 2px var(--accent-soft);
@@ -440,6 +558,16 @@
         background: transparent;
         color: var(--muted);
         font-size: 11px;
+      }
+
+      .button:disabled,
+      .preset-button:disabled,
+      .mode-button:disabled,
+      .section-button:disabled,
+      .chip-button:disabled {
+        cursor: wait;
+        opacity: 0.56;
+        transform: none !important;
       }
 
       .sr-only {
@@ -646,12 +774,18 @@
 
       .player-wrap {
         min-height: 0;
+        min-width: 0;
+        width: 100%;
+        max-width: 100%;
         overflow: auto;
       }
 
       #player {
+        position: relative;
         min-height: 0;
+        min-width: 0;
         width: 100%;
+        max-width: 100%;
       }
 
       #player .rr-player {
@@ -686,6 +820,303 @@
 
       .error strong {
         color: var(--danger);
+      }
+
+      .chart-overview {
+        display: grid;
+        grid-template-rows: auto minmax(286px, 0.85fr) auto;
+        gap: 0;
+        min-height: 100%;
+        max-width: 100%;
+        overflow: auto;
+      }
+
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(6, minmax(0, 1fr));
+        border-bottom: 1px solid var(--line);
+      }
+
+      .metric-card {
+        display: grid;
+        gap: 2px;
+        min-width: 0;
+        min-height: 58px;
+        appearance: none;
+        border: 0;
+        border-right: 1px solid var(--line);
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        font: inherit;
+        padding: 9px 12px;
+        text-align: left;
+      }
+
+      .metric-card.is-skeleton {
+        cursor: default;
+        pointer-events: none;
+      }
+
+      .metric-card:last-child {
+        border-right: 0;
+      }
+
+      .metric-card:hover,
+      .metric-card.is-selected {
+        background: var(--surface-soft);
+      }
+
+      .metric-card.is-selected {
+        box-shadow: inset 0 -2px 0 var(--accent);
+      }
+
+      .metric-card:focus-visible,
+      .breakdown-row:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: -2px;
+      }
+
+      .metric-card span,
+      .chart-meta,
+      .chart-legend {
+        color: var(--muted);
+        font-size: 11px;
+      }
+
+      .metric-card strong {
+        overflow: hidden;
+        font-family: var(--mono);
+        font-size: 16px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .metric-card code,
+      .chart-meta code {
+        display: block;
+        overflow: hidden;
+        max-width: 100%;
+        color: var(--faint);
+        font-family: var(--mono);
+        font-size: 10px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .chart-panel {
+        display: grid;
+        position: relative;
+        grid-template-rows: auto minmax(0, 1fr);
+        min-height: 0;
+        min-width: 0;
+        overflow: hidden;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .chart-panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: nowrap;
+        gap: 12px;
+        padding: 9px 12px 4px;
+      }
+
+      .chart-panel-head .label {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .chart-panel-head .chart-meta {
+        flex: 0 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-align: right;
+      }
+
+      .chart-panel-head .chart-legend {
+        flex: 0 1 auto;
+        justify-content: flex-end;
+        min-width: 0;
+      }
+
+      .chart-canvas {
+        position: relative;
+        min-height: 230px;
+        padding: 2px 12px 10px;
+      }
+
+      .chart-svg {
+        display: block;
+        width: 100%;
+        height: 100%;
+        min-height: 220px;
+      }
+
+      .chart-legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 7px 12px;
+      }
+
+      .legend-key {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+      }
+
+      .legend-swatch {
+        width: 9px;
+        height: 9px;
+        border-radius: 999px;
+        background: var(--accent);
+      }
+
+      .breakdown-grid {
+        display: grid;
+        grid-auto-flow: dense;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        background: var(--surface);
+        border-bottom: 1px solid var(--line);
+      }
+
+      .breakdown-list {
+        display: grid;
+        align-content: start;
+        gap: 0;
+        padding: 4px 0 12px;
+      }
+
+      .skeleton-line,
+      .skeleton-row::before,
+      .skeleton-row::after {
+        display: block;
+        border-radius: 2px;
+        background: linear-gradient(90deg, var(--surface-soft), #f8fafb, var(--surface-soft));
+        background-size: 220% 100%;
+        animation: skeleton-pulse 1.1s ease-in-out infinite;
+        content: "";
+      }
+
+      .skeleton-line {
+        height: 10px;
+      }
+
+      .skeleton-line.short {
+        width: 44%;
+      }
+
+      .skeleton-line.medium {
+        width: 68%;
+      }
+
+      .skeleton-line.long {
+        width: 86%;
+      }
+
+      .skeleton-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 42px;
+        gap: 12px;
+        align-items: center;
+        min-height: 28px;
+        padding: 6px 12px;
+      }
+
+      .skeleton-row::before {
+        width: var(--skeleton-width, 74%);
+        height: 11px;
+      }
+
+      .skeleton-row::after {
+        width: 34px;
+        height: 11px;
+        justify-self: end;
+      }
+
+      @keyframes skeleton-pulse {
+        to {
+          background-position: -220% 0;
+        }
+      }
+
+      .breakdown-grid .chart-panel {
+        border-left: 1px solid var(--line);
+        border-bottom: 0;
+        background: var(--surface);
+      }
+
+      .breakdown-grid .chart-panel:first-child {
+        grid-column: span 2;
+        border-left: 0;
+      }
+
+      .breakdown-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 8px;
+        align-items: center;
+        position: relative;
+        width: 100%;
+        appearance: none;
+        border: 0;
+        border-radius: 0;
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        font: inherit;
+        overflow: hidden;
+        padding: 4px 12px;
+        text-align: left;
+      }
+
+      .breakdown-row:hover {
+        background: #eef2ff;
+      }
+
+      .breakdown-row.is-selected {
+        background: rgb(15 23 42 / 8%);
+      }
+
+      .breakdown-row.is-other {
+        cursor: default;
+        color: var(--muted);
+      }
+
+      .breakdown-row.is-other:hover {
+        background: transparent;
+      }
+
+      .breakdown-row::before {
+        position: absolute;
+        inset: 0 auto 0 0;
+        width: var(--bar-width, 0%);
+        background: rgba(107, 124, 255, 0.12);
+        content: "";
+      }
+
+      .breakdown-label {
+        position: relative;
+        z-index: 1;
+        overflow: hidden;
+        min-width: 0;
+        font-size: 11px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .breakdown-value {
+        position: relative;
+        z-index: 1;
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 11px;
+        font-weight: 650;
+        text-align: right;
       }
 
       .facts {
@@ -753,6 +1184,20 @@
         color: var(--ink);
         padding: 9px 12px;
         text-align: left;
+      }
+
+      .context-row {
+        grid-template-columns: 78px minmax(0, 1fr);
+        cursor: default;
+      }
+
+      @media (hover: hover) {
+        .context-row:hover {
+          background: transparent;
+          border-color: var(--line);
+          color: var(--ink);
+          transform: none;
+        }
       }
 
       .timeline-time {
@@ -876,6 +1321,15 @@
           display: flex;
           width: 100%;
         }
+
+        .metric-grid,
+        .breakdown-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .breakdown-grid .chart-panel:first-child {
+          grid-column: span 1;
+        }
       }
     </style>
   </head>
@@ -884,56 +1338,47 @@
       <aside class="rail" id="rail">
         <div class="rail-content" id="railContent">
           <header class="topbar">
-            <span class="brand-mark" aria-label="Hogflare" role="img">
-              <svg viewBox="0 0 64 72" aria-hidden="true" fill="none" stroke="currentColor">
-                <path
-                  d="M12 54c-5-10-4-28 5-39C24 6 38 5 48 13c8 7 11 20 7 31-3 10-11 17-23 17-9 0-16-2-20-7Z"
-                  stroke-width="4"
-                  stroke-linejoin="round"
-                />
-                <path d="M19 18 13 8M29 12 27 3M42 14 45 5" stroke-width="4" stroke-linecap="round" />
-                <path d="M24 25c-4-3-9-2-11 3M43 25c4-4 10-3 12 2" stroke-width="4" stroke-linecap="round" />
-                <path
-                  d="M23 42c3-5 15-6 20-1 3 3 2 8-2 11-6 4-17 3-21-1-3-3-1-7 3-9Z"
-                  stroke-width="4"
-                  stroke-linejoin="round"
-                />
-                <path d="M27 44v5M37 44v5" stroke-width="4" stroke-linecap="round" />
-                <path d="M24 35h.1M42 35h.1" stroke-width="5" stroke-linecap="round" />
-                <path d="M16 60v6M45 59v7" stroke-width="4" stroke-linecap="round" />
-              </svg>
-            </span>
+            <div class="topbar-primary">
+              <span class="brand-mark" aria-label="Hogflare" role="img">
+                <svg viewBox="0 0 64 72" aria-hidden="true" fill="none" stroke="currentColor">
+                  <path
+                    d="M12 54c-5-10-4-28 5-39C24 6 38 5 48 13c8 7 11 20 7 31-3 10-11 17-23 17-9 0-16-2-20-7Z"
+                    stroke-width="4"
+                    stroke-linejoin="round"
+                  />
+                  <path d="M19 18 13 8M29 12 27 3M42 14 45 5" stroke-width="4" stroke-linecap="round" />
+                  <path d="M24 25c-4-3-9-2-11 3M43 25c4-4 10-3 12 2" stroke-width="4" stroke-linecap="round" />
+                  <path
+                    d="M23 42c3-5 15-6 20-1 3 3 2 8-2 11-6 4-17 3-21-1-3-3-1-7 3-9Z"
+                    stroke-width="4"
+                    stroke-linejoin="round"
+                  />
+                  <path d="M27 44v5M37 44v5" stroke-width="4" stroke-linecap="round" />
+                  <path d="M24 35h.1M42 35h.1" stroke-width="5" stroke-linecap="round" />
+                  <path d="M16 60v6M45 59v7" stroke-width="4" stroke-linecap="round" />
+                </svg>
+              </span>
+              <nav class="section-switch" aria-label="Viewer section">
+                <button class="section-button" id="analyticsSection" type="button" aria-selected="true">
+                  Analytics
+                </button>
+                <button class="section-button" id="replaySection" type="button" aria-selected="false">
+                  Replays
+                </button>
+              </nav>
+            </div>
             <span class="status" id="status" hidden>idle</span>
           </header>
 
           <section class="rail-body">
           <form class="filters" id="filters">
-            <div class="field wide">
-              <label class="label" for="apiKey">API key</label>
-              <input id="apiKey" name="api_key" autocomplete="off" placeholder="phc_..." />
-            </div>
-            <div class="field">
-              <label class="label" for="distinctId">Distinct ID</label>
-              <input id="distinctId" name="distinct_id" autocomplete="off" placeholder="user_123" />
-            </div>
-            <div class="field">
-              <label class="label" for="sessionId">Session ID</label>
-              <input id="sessionId" name="session_id" autocomplete="off" placeholder="$session_id" />
-            </div>
-            <div class="field wide">
-              <label class="label" for="url">URL contains</label>
-              <input id="url" name="url" autocomplete="off" placeholder="/checkout" />
-            </div>
-            <div class="field wide">
-              <label class="label" for="eventName">Event name</label>
-              <input id="eventName" name="event_name" autocomplete="off" placeholder="Product Viewed" />
-            </div>
             <div class="date-range" role="group" aria-labelledby="dateRangeLabel">
               <span class="label date-range-label" id="dateRangeLabel">Date range</span>
               <div class="date-presets" aria-label="Date range presets">
                 <button class="preset-button" type="button" data-date-preset="today">Today</button>
                 <button class="preset-button" type="button" data-date-preset="24h">Last 24h</button>
                 <button class="preset-button" type="button" data-date-preset="7d">Last 7d</button>
+                <button class="preset-button" type="button" data-date-preset="30d">Last 30d</button>
                 <button class="preset-button" type="button" data-date-preset="clear">Clear dates</button>
               </div>
               <div class="date-inputs">
@@ -947,23 +1392,126 @@
                 </label>
               </div>
             </div>
-            <div class="field">
+            <div class="field" data-section="replays">
+              <label class="label" for="distinctId">Distinct ID</label>
+              <input id="distinctId" name="distinct_id" autocomplete="off" placeholder="user_123" />
+            </div>
+            <div class="field" data-section="replays">
+              <label class="label" for="sessionId">Session ID</label>
+              <input id="sessionId" name="session_id" autocomplete="off" placeholder="$session_id" />
+            </div>
+            <div class="field wide">
+              <label class="label" for="url">URL contains</label>
+              <input id="url" name="url" autocomplete="off" placeholder="/checkout" />
+            </div>
+            <div class="field wide">
+              <label class="label" for="eventName">Event name</label>
+              <input id="eventName" name="event_name" autocomplete="off" placeholder="Product Viewed" />
+            </div>
+            <div class="section-controls" data-section="analytics">
+              <div class="analytics-query-grid">
+                <div class="field wide">
+                  <label class="label" for="metric">Metric</label>
+                  <select id="metric" name="metric">
+                    <optgroup label="Events">
+                      <option value="events.event_count">Events</option>
+                      <option value="events.unique_users">Users</option>
+                      <option value="events.snapshot_events">Replay chunks</option>
+                    </optgroup>
+                    <optgroup label="Pageviews">
+                      <option value="pageviews.pageviews">Pageviews</option>
+                    </optgroup>
+                    <optgroup label="Sessions">
+                      <option value="sessions.session_count">SDK sessions</option>
+                      <option value="sessions.average_session_seconds">Avg session</option>
+                    </optgroup>
+                  </select>
+                </div>
+                <div class="field wide">
+                  <label class="label" for="dimension">Breakdown</label>
+                  <select id="dimension" name="dimension">
+                    <optgroup label="Events">
+                      <option value="events.event_type" data-model="events">Event</option>
+                      <option value="events.browser" data-model="events">Browser</option>
+                      <option value="events.os" data-model="events">OS</option>
+                      <option value="events.device_type" data-model="events">Device</option>
+                      <option value="events.host" data-model="events">Host</option>
+                      <option value="events.referrer_domain" data-model="events">Referring domain</option>
+                      <option value="events.referrer" data-model="events">Referrer</option>
+                      <option value="events.geo_country_code" data-model="events">Country</option>
+                      <option value="events.geo_region" data-model="events">Region</option>
+                      <option value="events.geo_city" data-model="events">City</option>
+                      <option value="events.geo_timezone" data-model="events">Timezone</option>
+                      <option value="events.cf_asn" data-model="events">ASN</option>
+                      <option value="events.utm_source" data-model="events">UTM source</option>
+                      <option value="events.utm_campaign" data-model="events">UTM campaign</option>
+                    </optgroup>
+                    <optgroup label="Pageviews">
+                      <option value="pageviews.pathname" data-model="pageviews">Path</option>
+                      <option value="pageviews.host" data-model="pageviews">Host</option>
+                      <option value="pageviews.referrer_domain" data-model="pageviews">Referring domain</option>
+                      <option value="pageviews.referrer" data-model="pageviews">Referrer</option>
+                      <option value="pageviews.browser" data-model="pageviews">Browser</option>
+                      <option value="pageviews.os" data-model="pageviews">OS</option>
+                      <option value="pageviews.device_type" data-model="pageviews">Device</option>
+                      <option value="pageviews.geo_country_code" data-model="pageviews">Country</option>
+                      <option value="pageviews.geo_region" data-model="pageviews">Region</option>
+                      <option value="pageviews.geo_city" data-model="pageviews">City</option>
+                      <option value="pageviews.geo_timezone" data-model="pageviews">Timezone</option>
+                      <option value="pageviews.cf_asn" data-model="pageviews">ASN</option>
+                      <option value="pageviews.utm_source" data-model="pageviews">UTM source</option>
+                      <option value="pageviews.utm_campaign" data-model="pageviews">UTM campaign</option>
+                    </optgroup>
+                    <optgroup label="Sessions">
+                      <option value="sessions.landing_path" data-model="sessions">Landing path</option>
+                      <option value="sessions.browser" data-model="sessions">Browser</option>
+                      <option value="sessions.os" data-model="sessions">OS</option>
+                      <option value="sessions.device_type" data-model="sessions">Device</option>
+                      <option value="sessions.referrer_domain" data-model="sessions">Referring domain</option>
+                      <option value="sessions.referrer" data-model="sessions">Referrer</option>
+                      <option value="sessions.geo_country_code" data-model="sessions">Country</option>
+                      <option value="sessions.geo_region" data-model="sessions">Region</option>
+                      <option value="sessions.geo_city" data-model="sessions">City</option>
+                      <option value="sessions.geo_timezone" data-model="sessions">Timezone</option>
+                      <option value="sessions.cf_asn" data-model="sessions">ASN</option>
+                      <option value="sessions.utm_source" data-model="sessions">UTM source</option>
+                    </optgroup>
+                  </select>
+                </div>
+                <div class="field wide">
+                  <label class="label" for="granularity">Trend grain</label>
+                  <select id="granularity" name="granularity">
+                    <option value="day">Day</option>
+                    <option value="week">Week</option>
+                    <option value="month">Month</option>
+                  </select>
+                </div>
+              </div>
+              <input id="semanticFilters" name="semantic_filters" type="hidden" />
+              <div
+                class="semantic-filter-strip is-hidden"
+                id="semanticFilterStrip"
+                data-testid="analytics-filter-pills"
+                aria-label="Active analytics filters"
+              ></div>
+            </div>
+            <div class="field" data-section="replays">
               <label class="label" for="minDuration">Min duration</label>
               <input id="minDuration" name="min_duration_secs" inputmode="numeric" placeholder="sec" />
             </div>
-            <div class="field">
+            <div class="field" data-section="replays">
               <label class="label" for="maxDuration">Max duration</label>
               <input id="maxDuration" name="max_duration_secs" inputmode="numeric" placeholder="sec" />
             </div>
-            <div class="field">
+            <div class="field" data-section="replays">
               <label class="label" for="minEvents">Min events</label>
               <input id="minEvents" name="min_events" inputmode="numeric" placeholder="count" />
             </div>
-            <div class="field">
+            <div class="field" data-section="replays">
               <label class="label" for="maxEvents">Max events</label>
               <input id="maxEvents" name="max_events" inputmode="numeric" placeholder="count" />
             </div>
-            <div class="field wide">
+            <div class="field wide" data-section="replays">
               <label class="label" for="limit">Limit</label>
               <input id="limit" name="limit" inputmode="numeric" value="100" />
             </div>
@@ -973,7 +1521,7 @@
             </div>
           </form>
 
-          <section class="result-controls" aria-label="Replay result controls">
+          <section class="result-controls" id="resultControls" aria-label="Replay result controls">
             <nav class="mode-switch" aria-label="Replay result type">
               <button class="mode-button" id="sessionMode" type="button" aria-selected="true">
                 Sessions
@@ -1026,7 +1574,7 @@
             </div>
           </section>
 
-          <div class="results-pane">
+          <div class="results-pane" id="resultsPane">
             <div class="results-head">
               <span class="label" id="resultsLabel">Recent sessions</span>
               <span class="count" id="resultCount">0</span>
@@ -1082,7 +1630,7 @@
         <header class="stage-head">
           <div class="stage-title">
             <strong id="activeTitle">No session selected</strong>
-            <span id="activeSubtitle">Search replay sessions or choose an analytics event.</span>
+            <span id="activeSubtitle">Search replay sessions or choose an event.</span>
           </div>
           <div class="actions">
             <button class="button secondary" id="copyLink" type="button">Copy link</button>
@@ -1102,31 +1650,31 @@
       <aside class="inspector" id="inspector">
         <div class="inspector-content" id="inspectorContent">
           <header class="inspector-head">
-            <h2>Session context</h2>
+            <h2 id="inspectorTitle">Session context</h2>
           </header>
           <section class="facts" aria-label="Session facts">
             <div class="fact">
-              <span>User</span>
+              <span id="detailDistinctLabel">User</span>
               <strong id="detailDistinct">-</strong>
             </div>
             <div class="fact">
-              <span>API key</span>
-              <strong id="detailApiKey">-</strong>
+              <span id="detailSecondaryLabel">First seen</span>
+              <strong id="detailSecondary">-</strong>
             </div>
             <div class="fact">
-              <span>Duration</span>
+              <span id="detailDurationLabel">Duration</span>
               <strong id="detailDuration">-</strong>
             </div>
             <div class="fact">
-              <span>Events</span>
+              <span id="detailEventsLabel">Events</span>
               <strong id="detailEvents">-</strong>
             </div>
             <div class="fact">
-              <span>Chunks</span>
+              <span id="detailChunksLabel">Chunks</span>
               <strong id="detailChunks">-</strong>
             </div>
             <div class="fact">
-              <span>First URL</span>
+              <span id="detailUrlLabel">First URL</span>
               <strong id="detailUrl">-</strong>
             </div>
           </section>
@@ -1191,15 +1739,23 @@
         app: document.getElementById("app"),
         filters: document.getElementById("filters"),
         status: document.getElementById("status"),
+        replaySection: document.getElementById("replaySection"),
+        analyticsSection: document.getElementById("analyticsSection"),
         sessionMode: document.getElementById("sessionMode"),
         eventMode: document.getElementById("eventMode"),
         funnelMode: document.getElementById("funnelMode"),
         frictionMode: document.getElementById("frictionMode"),
         personMode: document.getElementById("personMode"),
+        resultControls: document.getElementById("resultControls"),
         modeOptions: document.getElementById("modeOptions"),
         funnelStepControls: document.getElementById("funnelStepControls"),
         signalChoices: document.getElementById("signalChoices"),
         datePresets: document.querySelector(".date-presets"),
+        metric: document.getElementById("metric"),
+        dimension: document.getElementById("dimension"),
+        granularity: document.getElementById("granularity"),
+        semanticFilters: document.getElementById("semanticFilters"),
+        semanticFilterStrip: document.getElementById("semanticFilterStrip"),
         submitButton: document.getElementById("submitButton"),
         clear: document.getElementById("clear"),
         reload: document.getElementById("reload"),
@@ -1208,12 +1764,20 @@
         copyLink: document.getElementById("copyLink"),
         resultsLabel: document.getElementById("resultsLabel"),
         resultCount: document.getElementById("resultCount"),
+        resultsPane: document.getElementById("resultsPane"),
         results: document.getElementById("results"),
         player: document.getElementById("player"),
         activeTitle: document.getElementById("activeTitle"),
         activeSubtitle: document.getElementById("activeSubtitle"),
+        inspectorTitle: document.getElementById("inspectorTitle"),
+        detailDistinctLabel: document.getElementById("detailDistinctLabel"),
+        detailSecondaryLabel: document.getElementById("detailSecondaryLabel"),
+        detailDurationLabel: document.getElementById("detailDurationLabel"),
+        detailEventsLabel: document.getElementById("detailEventsLabel"),
+        detailChunksLabel: document.getElementById("detailChunksLabel"),
+        detailUrlLabel: document.getElementById("detailUrlLabel"),
         detailDistinct: document.getElementById("detailDistinct"),
-        detailApiKey: document.getElementById("detailApiKey"),
+        detailSecondary: document.getElementById("detailSecondary"),
         detailDuration: document.getElementById("detailDuration"),
         detailEvents: document.getElementById("detailEvents"),
         detailChunks: document.getElementById("detailChunks"),
@@ -1227,7 +1791,10 @@
       };
 
       const state = {
-        mode: "sessions",
+        mode: "overview",
+        section: "analytics",
+        lastReplayMode: "sessions",
+        charts: null,
         sessions: [],
         events: [],
         funnels: [],
@@ -1245,6 +1812,10 @@
         playerWidth: 0,
         playerHeight: 0,
         playerResizeTimer: null,
+        chartResizeTimer: null,
+        analyticsRequestId: 0,
+        analyticsLoading: false,
+        analyticsPendingPanels: new Set(),
         railCollapsed: false,
         inspectorCollapsed: false,
       };
@@ -1252,11 +1823,54 @@
       const playerControllerHeight = 80;
 
       const modes = {
+        overview: { label: "Product analytics" },
         sessions: { label: "Recent sessions" },
-        events: { label: "Analytics events" },
+        events: { label: "Events" },
         funnels: { label: "Funnel replay" },
         friction: { label: "Friction signals" },
         person: { label: "Person journey" },
+      };
+
+      const analyticsMetricModels = {
+        "events.event_count": "events",
+        "events.unique_users": "events",
+        "events.snapshot_events": "events",
+        "pageviews.pageviews": "pageviews",
+        "sessions.session_count": "sessions",
+        "sessions.average_session_seconds": "sessions",
+      };
+
+      const analyticsDefaultDimensions = {
+        events: "events.event_type",
+        pageviews: "pageviews.pathname",
+        sessions: "sessions.landing_path",
+      };
+      const analyticsBreakdownLimit = 10;
+
+      const analyticsPanelOrder = [
+        "top_events",
+        "top_pages",
+        "domains",
+        "referring_domains",
+        "referrers",
+        "browsers",
+        "countries",
+        "regions",
+        "cities",
+        "summary",
+        "series",
+        "focus_breakdown",
+      ];
+      const analyticsBuiltInBreakdownPanels = {
+        "events.event_type": "top_events",
+        "pageviews.pathname": "top_pages",
+        "pageviews.host": "domains",
+        "pageviews.referrer_domain": "referring_domains",
+        "pageviews.referrer": "referrers",
+        "events.browser": "browsers",
+        "events.geo_country_code": "countries",
+        "events.geo_region": "regions",
+        "events.geo_city": "cities",
       };
 
       const funnelEventOptions = [
@@ -1269,6 +1883,8 @@
         "Demo Requested",
       ];
       const defaultFunnelSteps = ["Viewed Pricing", "Checkout Started", ""];
+      const analyticsPath = "/analytics";
+      const replayPath = "/replay";
 
       function paramsFromForm(options = {}) {
         const params = new URLSearchParams();
@@ -1297,13 +1913,24 @@
 
       function skippedFields(mode) {
         const durationFields = ["min_duration_secs", "max_duration_secs", "min_events", "max_events"];
+        const replayIdentityFields = ["distinct_id", "session_id"];
+        const analyticsFields = ["metric", "dimension", "granularity", "semantic_filters"];
         const byMode = {
-          sessions: ["steps", "signal"],
-          events: [...durationFields, "steps", "signal"],
-          funnels: [...durationFields, "event_name", "signal"],
-          friction: ["event_name", "steps"],
-          person: [...durationFields, "steps", "signal"],
-          sessionLoad: ["session_id", "url", "event_name", "steps", "signal", ...durationFields],
+          overview: [...durationFields, ...replayIdentityFields, "limit", "steps", "signal"],
+          sessions: [...analyticsFields, "steps", "signal"],
+          events: [...analyticsFields, ...durationFields, "steps", "signal"],
+          funnels: [...analyticsFields, ...durationFields, "event_name", "signal"],
+          friction: [...analyticsFields, "event_name", "steps"],
+          person: [...analyticsFields, ...durationFields, "steps", "signal"],
+          sessionLoad: [
+            ...analyticsFields,
+            "session_id",
+            "url",
+            "event_name",
+            "steps",
+            "signal",
+            ...durationFields,
+          ],
         };
         return new Set(byMode[mode] || []);
       }
@@ -1332,7 +1959,8 @@
       function applyDatePreset(preset) {
         if (preset === "clear") {
           setDateRange(null, null);
-          runSearch();
+          setDatePresetState("clear");
+          requestSearchForCurrentMode();
           return;
         }
         const to = new Date();
@@ -1343,16 +1971,40 @@
           from.setDate(from.getDate() - 1);
         } else if (preset === "7d") {
           from.setDate(from.getDate() - 7);
+        } else if (preset === "30d") {
+          from.setDate(from.getDate() - 30);
         } else {
           return;
         }
         setDateRange(from, to);
-        runSearch();
+        setDatePresetState(preset);
+        requestSearchForCurrentMode();
       }
 
-      function setStatus(text, ok = false) {
+      function setDatePresetState(preset) {
+        for (const button of els.datePresets.querySelectorAll("[data-date-preset]")) {
+          button.classList.toggle("is-selected", button.dataset.datePreset === preset);
+        }
+      }
+
+      function setStatus(text, ok = false, loading = false) {
+        els.status.hidden = false;
+        els.status.removeAttribute("hidden");
         els.status.textContent = text;
         els.status.classList.toggle("is-ok", ok);
+        els.status.classList.toggle("is-loading", loading);
+      }
+
+      function clearStatus() {
+        els.status.hidden = true;
+        els.status.textContent = "";
+        els.status.classList.remove("is-ok", "is-loading");
+      }
+
+      function setAnalyticsLoading(loading) {
+        state.analyticsLoading = loading;
+        els.player.classList.toggle("is-loading", loading);
+        els.player.toggleAttribute("aria-busy", loading);
       }
 
       function initModeControls() {
@@ -1377,6 +2029,110 @@
           button.addEventListener("click", () => setSignal(button.dataset.signal || "", { search: true }));
         }
         setSignal("");
+      }
+
+      function initAnalyticsControls() {
+        for (const select of [els.metric, els.dimension, els.granularity]) {
+          select.addEventListener("change", () => {
+            if (select === els.metric) syncAnalyticsDimensions();
+            if (state.mode === "overview") requestAnalyticsSearch();
+          });
+        }
+        syncAnalyticsDimensions();
+        renderSemanticFilters();
+      }
+
+      function syncAnalyticsDimensions() {
+        const model = analyticsMetricModels[els.metric.value] || "events";
+        const defaultDimension = analyticsDefaultDimensions[model];
+        let selectedStillValid = false;
+        for (const option of els.dimension.options) {
+          const enabled = !option.dataset.model || option.dataset.model === model;
+          option.disabled = !enabled;
+          option.hidden = !enabled;
+          if (enabled && option.value === els.dimension.value) selectedStillValid = true;
+        }
+        if (!selectedStillValid) els.dimension.value = defaultDimension;
+      }
+
+      function semanticFilters() {
+        try {
+          const parsed = JSON.parse(els.semanticFilters.value || "{}");
+          return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+        } catch (_) {
+          return {};
+        }
+      }
+
+      function writeSemanticFilters(filters) {
+        const normalized = {};
+        for (const [dimension, values] of Object.entries(filters || {})) {
+          const cleanValues = [...new Set((Array.isArray(values) ? values : [values]).map(normalizeFilterValue).filter(Boolean))];
+          if (cleanValues.length) normalized[dimension] = cleanValues;
+        }
+        els.semanticFilters.value = Object.keys(normalized).length ? JSON.stringify(normalized) : "";
+        renderSemanticFilters();
+      }
+
+      function normalizeFilterValue(value) {
+        return String(value ?? "").trim();
+      }
+
+      function toggleSemanticFilter(dimension, value) {
+        const normalizedValue = normalizeFilterValue(value);
+        if (!dimension || !normalizedValue) return;
+        const filters = semanticFilters();
+        const selected = new Set((filters[dimension] || []).map(normalizeFilterValue));
+        if (selected.has(normalizedValue)) selected.delete(normalizedValue);
+        else selected.add(normalizedValue);
+        if (selected.size) filters[dimension] = [...selected];
+        else delete filters[dimension];
+        writeSemanticFilters(filters);
+        if (state.mode === "overview") requestAnalyticsSearch();
+      }
+
+      function removeSemanticFilter(dimension, value) {
+        const normalizedValue = normalizeFilterValue(value);
+        const filters = semanticFilters();
+        const values = (filters[dimension] || []).map(normalizeFilterValue).filter((item) => item !== normalizedValue);
+        if (values.length) filters[dimension] = values;
+        else delete filters[dimension];
+        writeSemanticFilters(filters);
+        if (state.mode === "overview") requestAnalyticsSearch();
+      }
+
+      function isSemanticFilterSelected(dimension, value) {
+        const normalizedValue = normalizeFilterValue(value);
+        return (semanticFilters()[dimension] || []).map(normalizeFilterValue).includes(normalizedValue);
+      }
+
+      function renderSemanticFilters() {
+        const filters = semanticFilters();
+        els.semanticFilterStrip.innerHTML = "";
+        const entries = Object.entries(filters).flatMap(([dimension, values]) =>
+          (values || []).map((value) => ({ dimension, value: normalizeFilterValue(value) })).filter((item) => item.value),
+        );
+        els.semanticFilterStrip.classList.toggle("is-hidden", !entries.length);
+        for (const item of entries) {
+          const pill = document.createElement("span");
+          pill.className = "semantic-filter-pill";
+          pill.dataset.dimension = item.dimension;
+          pill.dataset.value = item.value;
+          const label = document.createElement("span");
+          label.textContent = `${semanticFilterLabel(item.dimension)}: ${item.value}`;
+          const button = document.createElement("button");
+          button.type = "button";
+          button.textContent = "×";
+          button.setAttribute("aria-label", `Remove ${item.value}`);
+          button.addEventListener("click", () => removeSemanticFilter(item.dimension, item.value));
+          pill.append(label, button);
+          els.semanticFilterStrip.appendChild(pill);
+        }
+      }
+
+      function semanticFilterLabel(dimension) {
+        const option = Array.from(els.dimension.options).find((candidate) => candidate.value === dimension);
+        return option?.textContent || dimension;
       }
 
       function updateStepsFromControls() {
@@ -1416,7 +2172,12 @@
       }
 
       function setMode(mode) {
+        if (mode !== "overview") cancelAnalyticsRequests();
         state.mode = mode;
+        state.section = mode === "overview" ? "analytics" : "replays";
+        if (state.section === "replays") state.lastReplayMode = mode;
+        syncSectionControls();
+        renderSemanticFilters();
         for (const [key, button] of [
           ["sessions", els.sessionMode],
           ["events", els.eventMode],
@@ -1426,8 +2187,9 @@
         ]) {
           button.setAttribute("aria-selected", mode === key ? "true" : "false");
         }
-        els.submitButton.textContent = "Search";
+        els.submitButton.textContent = state.section === "analytics" ? "Analyze" : "Search";
         els.resultsLabel.textContent = modes[mode].label;
+        els.resultControls.classList.toggle("is-hidden", state.section === "analytics");
         let hasModeOptions = false;
         for (const field of document.querySelectorAll(".mode-field")) {
           const enabled = field.dataset.modes.split(" ").includes(mode);
@@ -1436,6 +2198,17 @@
         }
         els.modeOptions.classList.toggle("is-hidden", !hasModeOptions);
         renderResults();
+      }
+
+      function syncSectionControls() {
+        const analyticsSelected = state.mode === "overview";
+        state.section = analyticsSelected ? "analytics" : "replays";
+        els.replaySection.setAttribute("aria-selected", analyticsSelected ? "false" : "true");
+        els.analyticsSection.setAttribute("aria-selected", analyticsSelected ? "true" : "false");
+        els.resultsPane.classList.toggle("is-hidden", analyticsSelected);
+        for (const field of document.querySelectorAll("[data-section]")) {
+          field.classList.toggle("is-hidden", field.dataset.section !== state.section);
+        }
       }
 
       function formatTime(value) {
@@ -1484,6 +2257,10 @@
 
       function renderResults() {
         els.results.innerHTML = "";
+        if (state.mode === "overview") {
+          els.resultCount.textContent = "0";
+          return;
+        }
         const items = resultItems();
         els.resultCount.textContent = String(items.length);
         for (const item of items) {
@@ -1500,11 +2277,30 @@
       }
 
       function resultRow(item) {
+        if (state.mode === "overview") return chartMetricRow(item);
         if (state.mode === "events") return eventRow(item);
         if (state.mode === "funnels") return funnelRow(item);
         if (state.mode === "friction") return frictionRow(item);
         if (state.mode === "person") return personRow(item);
         return sessionRow(item);
+      }
+
+      function chartMetricRow(metric) {
+        const row = document.createElement("button");
+        row.type = "button";
+        row.className = "row-button";
+        row.addEventListener("click", () => renderChartContext(metric));
+
+        const title = document.createElement("div");
+        title.className = "row-title";
+        title.textContent = metric.label;
+
+        const meta = document.createElement("div");
+        meta.className = "row-meta";
+        meta.append(textNode(metric.display_value), textNode(metric.semantic_ref));
+
+        row.append(title, meta);
+        return row;
       }
 
       function sessionRow(session) {
@@ -1632,12 +2428,105 @@
         return span;
       }
 
-      async function requestJson(path, params) {
+      function replaceUrl(path, params) {
+        const query = params.toString();
+        history.replaceState(null, "", query ? `${path}?${query}` : path);
+      }
+
+      function replaceAnalyticsUrlFromForm() {
+        const params = paramsFromForm({ mode: "overview" });
+        replaceUrl(analyticsPath, params);
+        return params;
+      }
+
+      function replaceReplayUrlFromForm(mode = state.mode) {
+        const params = paramsFromForm({ mode });
+        if (mode && mode !== "sessions") params.set("mode", mode);
+        replaceUrl(replayPath, params);
+        return params;
+      }
+
+      function requestSearchForCurrentMode() {
+        if (state.mode === "overview") requestAnalyticsSearch();
+        else {
+          replaceReplayUrlFromForm();
+          runSearch();
+        }
+      }
+
+      function requestAnalyticsSearch() {
+        if (state.mode !== "overview") {
+          runSearch();
+          return;
+        }
+        replaceAnalyticsUrlFromForm();
+        runSearch();
+      }
+
+      async function requestJson(path, params, options = {}) {
         const query = params?.toString();
-        const response = await fetch(query ? `${path}?${query}` : path);
+        const response = await fetch(query ? `${path}?${query}` : path, options);
         const body = await response.json();
         if (!response.ok) throw new Error(body.error || "Replay request failed.");
         return body;
+      }
+
+      function cancelAnalyticsRequests() {
+        state.analyticsRequestId += 1;
+        state.analyticsPendingPanels.clear();
+        setAnalyticsLoading(false);
+      }
+
+      async function loadCharts() {
+        const requestId = ++state.analyticsRequestId;
+        const params = paramsFromForm({ mode: "overview" });
+        const panels = analyticsPanelsForCurrentQuery();
+        state.analyticsPendingPanels = new Set(panels);
+        clearStatus();
+        setAnalyticsLoading(true);
+        try {
+          state.mode = "overview";
+          syncSectionControls();
+          state.charts = analyticsShellFromForm();
+          state.selectedSession = null;
+          state.sessionPayload = null;
+          renderResults();
+          renderCharts(state.charts);
+          renderChartContext();
+          replaceUrl(analyticsPath, params);
+          let failures = 0;
+          await Promise.all(
+            panels.map(async (panel) => {
+              const panelParams = new URLSearchParams(params);
+              panelParams.set("panel", panel);
+              try {
+                const body = await requestJson("/analytics/api/charts", panelParams);
+                if (requestId !== state.analyticsRequestId) return;
+                mergeAnalyticsPanel(panel, body);
+              } catch (error) {
+                if (error?.name === "AbortError" || requestId !== state.analyticsRequestId) return;
+                failures += 1;
+              } finally {
+                if (requestId === state.analyticsRequestId) {
+                  state.analyticsPendingPanels.delete(panel);
+                  renderCharts(state.charts);
+                  renderChartContext();
+                }
+              }
+            }),
+          );
+          if (requestId !== state.analyticsRequestId) return;
+          if (failures === panels.length) throw new Error("Analytics panels failed to load.");
+          if (failures) setStatus(`${failures} analytics panels failed`);
+          else clearStatus();
+        } finally {
+          if (requestId === state.analyticsRequestId) {
+            setAnalyticsLoading(false);
+            state.analyticsPendingPanels.clear();
+            renderAnalyticsFacts(state.charts);
+            renderChartContext();
+          }
+        }
       }
 
       async function loadSessions(options = {}) {
@@ -1724,7 +2613,7 @@
         await loadSessions({ silent: true, keepSelection: true });
         const match = state.sessions.find((session) => session.session_id === event.session_id) || state.sessions[0];
         if (!match) {
-          showMessage("empty", "No recording", "No replay session matched this analytics event.");
+          showMessage("empty", "No recording", "No replay session matched this event.");
           return;
         }
         await loadSession(match.session_id, anchorForEvent(event, match));
@@ -1791,17 +2680,558 @@
         return Math.max(0, eventAt - sessionStart);
       }
 
+      function analyticsShellFromForm() {
+        const focus = analyticsFocusFromCurrentForm();
+        return {
+          focus: {
+            ...focus,
+            metric_label: analyticsMetricLabel(focus.metric),
+            dimension_label: analyticsDimensionLabel(focus.dimension),
+          },
+          summary: state.charts?.summary || [],
+          series: [],
+          breakdowns: [],
+        };
+      }
+
+      function analyticsPanelsForCurrentQuery() {
+        const focus = analyticsFocusFromCurrentForm();
+        return analyticsPanelOrder.filter((panel) => {
+          if (panel !== "focus_breakdown") return true;
+          if (analyticsBuiltInBreakdownPanels[focus.dimension]) return false;
+          const dimensionName = focus.dimension.split(".").at(-1);
+          return !["geo_country_code", "geo_region", "geo_city"].includes(dimensionName);
+        });
+      }
+
+      function mergeAnalyticsPanel(panel, body) {
+        if (!state.charts) state.charts = analyticsShellFromForm();
+        if (body?.focus) state.charts.focus = body.focus;
+        if (panel === "summary") state.charts.summary = body?.summary || [];
+        if (panel === "series") state.charts.series = body?.series || [];
+        for (const breakdown of body?.breakdowns || []) {
+          breakdown.panel_key = panel;
+          const existingIndex = state.charts.breakdowns.findIndex((item) => sameChartBreakdown(item, breakdown));
+          if (existingIndex >= 0) state.charts.breakdowns[existingIndex] = breakdown;
+          else state.charts.breakdowns.push(breakdown);
+        }
+        state.charts.breakdowns.sort(
+          (left, right) => chartBreakdownOrder(left) - chartBreakdownOrder(right),
+        );
+      }
+
+      function sameChartBreakdown(left, right) {
+        if (left?.panel_key || right?.panel_key) return left?.panel_key === right?.panel_key;
+        return left?.model === right?.model && left?.dimension === right?.dimension && left?.metric === right?.metric;
+      }
+
+      function chartBreakdownOrder(breakdown) {
+        const panelIndex = analyticsPanelOrder.indexOf(breakdown?.panel_key);
+        if (panelIndex >= 0) return panelIndex;
+        const key = `${breakdown?.model}.${breakdown?.dimension}`;
+        const focus = state.charts?.focus || analyticsFocusFromCurrentForm();
+        const selectedMetric = focus.metric;
+        const selectedDimension = focus.dimension;
+        if (breakdown?.metric === selectedMetric && key === selectedDimension) return 0;
+        const order = [
+          "events.event_type",
+          "pageviews.pathname",
+          "pageviews.host",
+          "pageviews.referrer_domain",
+          "pageviews.referrer",
+          "events.browser",
+          "events.geo_country_code",
+          "events.geo_region",
+          "events.geo_city",
+        ];
+        const index = order.indexOf(key);
+        return index < 0 ? order.length + 1 : index + 1;
+      }
+
+      function renderCharts(charts) {
+        destroyPlayer();
+        state.playerEvents = [];
+        state.playerAnchorMs = 0;
+        state.playerWidth = 0;
+        state.playerHeight = 0;
+        els.player.style.minHeight = "";
+        els.player.innerHTML = "";
+        renderAnalyticsFacts(charts);
+        els.activeTitle.textContent = "Product analytics";
+        els.activeSubtitle.textContent = analyticsQuerySubtitle(charts?.focus || analyticsFocusFromCurrentForm());
+
+        const wrap = document.createElement("div");
+        wrap.className = "chart-overview";
+        wrap.append(renderMetricGrid(charts?.summary || [], charts?.focus?.metric));
+        wrap.append(renderSeriesPanel(charts));
+        wrap.append(renderBreakdownGrid(charts?.breakdowns || []));
+        els.player.appendChild(wrap);
+      }
+
+      function renderMetricGrid(metrics, selectedMetricRef = "") {
+        const grid = document.createElement("section");
+        grid.className = "metric-grid";
+        grid.setAttribute("aria-label", "Analytics metrics");
+        const pending = state.analyticsPendingPanels.has("summary");
+        grid.classList.toggle("is-pending", pending);
+        if (!metrics.length) {
+          if (pending) {
+            for (let index = 0; index < 6; index += 1) {
+              grid.appendChild(renderMetricSkeletonCard(index));
+            }
+          } else {
+            const empty = document.createElement("div");
+            empty.className = "empty";
+            empty.innerHTML = "<strong>No metrics</strong><span>Adjust filters and reload.</span>";
+            grid.appendChild(empty);
+          }
+          return grid;
+        }
+        for (const metric of metrics) {
+          const card = document.createElement("button");
+          card.type = "button";
+          card.className = "metric-card";
+          card.dataset.metric = metric.semantic_ref;
+          card.classList.toggle("is-selected", metric.semantic_ref === selectedMetricRef);
+          card.addEventListener("click", () => selectAnalyticsMetric(metric.semantic_ref));
+          const label = document.createElement("span");
+          label.textContent = metric.label;
+          const value = document.createElement("strong");
+          value.textContent = metric.display_value;
+          const ref = document.createElement("code");
+          ref.textContent = metric.semantic_ref;
+          card.append(label, value, ref);
+          grid.appendChild(card);
+        }
+        return grid;
+      }
+
+      function renderMetricSkeletonCard(index) {
+        const card = document.createElement("div");
+        card.className = "metric-card is-skeleton";
+        card.setAttribute("aria-hidden", "true");
+        for (const size of [index % 2 ? "medium" : "short", "long", "medium"]) {
+          const line = document.createElement("span");
+          line.className = `skeleton-line ${size}`;
+          card.appendChild(line);
+        }
+        return card;
+      }
+
+      function selectAnalyticsMetric(metricRef) {
+        if (!analyticsMetricModels[metricRef]) return;
+        els.metric.value = metricRef;
+        syncAnalyticsDimensions();
+        if (state.mode === "overview") requestAnalyticsSearch();
+      }
+
+      function renderSeriesPanel(charts) {
+        const series = charts?.series || [];
+        const config = seriesConfig(charts);
+        const panel = document.createElement("section");
+        panel.className = "chart-panel";
+        panel.classList.toggle("is-pending", state.analyticsPendingPanels.has("series"));
+        panel.setAttribute("aria-label", `${grainLabel(charts?.focus?.granularity)} trend`);
+
+        const head = document.createElement("div");
+        head.className = "chart-panel-head";
+        const label = document.createElement("span");
+        label.className = "label";
+        label.textContent = `${grainLabel(charts?.focus?.granularity)} trend`;
+        head.append(label, renderLegend(config));
+
+        const canvas = document.createElement("div");
+        canvas.className = "chart-canvas";
+        renderSeriesIntoCanvas(canvas, series, config, charts?.focus);
+        window.requestAnimationFrame(() => {
+          if (canvas.isConnected) renderSeriesIntoCanvas(canvas, series, config, charts?.focus);
+        });
+
+        panel.append(head, canvas);
+        return panel;
+      }
+
+      function renderBreakdownGrid(breakdowns) {
+        const grid = document.createElement("section");
+        grid.className = "breakdown-grid";
+        grid.setAttribute("aria-label", "Metric breakdowns");
+        const rendered = new Set();
+        const breakdownsByPanel = new Map(
+          breakdowns.map((breakdown) => [breakdown.panel_key || breakdownPanelKey(breakdown), breakdown]),
+        );
+        for (const panel of analyticsPanelsForCurrentQuery().filter((item) => !["summary", "series"].includes(item))) {
+          const breakdown = breakdownsByPanel.get(panel);
+          if (breakdown) {
+            rendered.add(breakdown);
+            grid.appendChild(renderBreakdownPanel(breakdown));
+          } else if (state.analyticsPendingPanels.has(panel)) {
+            grid.appendChild(renderLoadingBreakdownPanel(panel));
+          }
+        }
+        for (const breakdown of breakdowns) {
+          if (!rendered.has(breakdown)) grid.appendChild(renderBreakdownPanel(breakdown));
+        }
+        return grid;
+      }
+
+      function renderBreakdownPanel(breakdown) {
+        const panel = document.createElement("section");
+        panel.className = "chart-panel";
+
+        const head = document.createElement("div");
+        head.className = "chart-panel-head";
+        const title = document.createElement("span");
+        title.className = "label";
+        title.textContent = breakdown.title;
+        const meta = document.createElement("span");
+        meta.className = "chart-meta";
+        const code = document.createElement("code");
+        code.textContent = `${breakdown.model}.${breakdown.dimension}`;
+        meta.appendChild(code);
+        head.append(title, meta);
+
+        const list = document.createElement("div");
+        list.className = "breakdown-list";
+        if (!breakdown.rows.length) {
+          const empty = document.createElement("div");
+          empty.className = "empty";
+          empty.innerHTML = "<strong>No rows</strong><span>No grouped values matched.</span>";
+          list.appendChild(empty);
+        } else {
+          for (const row of breakdown.rows) {
+            list.appendChild(renderBreakdownRow(row, breakdown));
+          }
+        }
+
+        panel.append(head, list);
+        return panel;
+      }
+
+      function renderLoadingBreakdownPanel(panel) {
+        const section = document.createElement("section");
+        section.className = "chart-panel is-pending";
+        const head = document.createElement("div");
+        head.className = "chart-panel-head";
+        const title = document.createElement("span");
+        title.className = "label";
+        title.textContent = loadingBreakdownTitle(panel);
+        const meta = document.createElement("span");
+        meta.className = "chart-meta";
+        head.append(title, meta);
+        const list = document.createElement("div");
+        list.className = "breakdown-list";
+        for (let index = 0; index < 6; index += 1) {
+          const row = document.createElement("div");
+          row.className = "skeleton-row";
+          row.style.setProperty("--skeleton-width", `${86 - index * 8}%`);
+          list.appendChild(row);
+        }
+        section.append(head, list);
+        return section;
+      }
+
+      function breakdownPanelKey(breakdown) {
+        const key = `${breakdown?.model}.${breakdown?.dimension}`;
+        const focus = state.charts?.focus || analyticsFocusFromCurrentForm();
+        if (breakdown?.metric === focus.metric && key === focus.dimension) return "focus_breakdown";
+        return analyticsBuiltInBreakdownPanels[key] || key;
+      }
+
+      function loadingBreakdownTitle(panel) {
+        const focus = state.charts?.focus || analyticsFocusFromCurrentForm();
+        const titles = {
+          focus_breakdown: analyticsDimensionTitle(focus.dimension),
+          top_events: "Top events",
+          top_pages: "Top pages",
+          domains: "Domains",
+          referring_domains: "Referring domains",
+          referrers: "Referrers",
+          browsers: "Browsers",
+          countries: "Countries",
+          regions: "Regions",
+          cities: "Cities",
+        };
+        return titles[panel] || "Breakdown";
+      }
+
+      function renderBreakdownRow(row, breakdown) {
+        const isOther = Boolean(row.is_other || row.isOther);
+        const wrap = document.createElement(isOther ? "div" : "button");
+        const dimensionRef = `${breakdown.model}.${breakdown.dimension}`;
+        if (!isOther) wrap.type = "button";
+        wrap.className = "breakdown-row";
+        wrap.classList.toggle("is-other", isOther);
+        if (!isOther) {
+          wrap.dataset.dimension = dimensionRef;
+          wrap.dataset.value = row.label;
+        }
+        wrap.style.setProperty("--bar-width", `${Math.round(Math.max(0, Math.min(100, row.percent || 0)))}%`);
+        wrap.classList.toggle("is-selected", !isOther && isSemanticFilterSelected(dimensionRef, row.label));
+        if (!isOther) wrap.addEventListener("click", () => toggleSemanticFilter(dimensionRef, row.label));
+        const label = document.createElement("span");
+        label.className = "breakdown-label";
+        label.textContent = row.label;
+        const value = document.createElement("span");
+        value.className = "breakdown-value";
+        value.textContent = formatNumber(row.value);
+        wrap.append(label, value);
+        return wrap;
+      }
+
+      function renderLegend(config) {
+        const legend = document.createElement("div");
+        legend.className = "chart-legend";
+        for (const item of config) {
+          const key = document.createElement("span");
+          key.className = "legend-key";
+          const swatch = document.createElement("span");
+          swatch.className = "legend-swatch";
+          swatch.style.background = item.color;
+          const label = document.createElement("span");
+          label.textContent = item.label;
+          key.append(swatch, label);
+          legend.appendChild(key);
+        }
+        return legend;
+      }
+
+      function chartCanvasSize(canvas) {
+        const style = window.getComputedStyle(canvas);
+        const paddingX = parseFloat(style.paddingLeft || "0") + parseFloat(style.paddingRight || "0");
+        const paddingY = parseFloat(style.paddingTop || "0") + parseFloat(style.paddingBottom || "0");
+        const rect = canvas.getBoundingClientRect();
+        const width = Math.floor((rect.width || canvas.clientWidth || 960) - paddingX);
+        const height = Math.floor((rect.height || canvas.clientHeight || 260) - paddingY);
+        return {
+          width: Math.max(420, width),
+          height: Math.max(220, height),
+        };
+      }
+
+      function renderSeriesIntoCanvas(canvas, series, config, focus) {
+        const { width, height } = chartCanvasSize(canvas);
+        canvas.replaceChildren(renderSeriesSvg(series, config, focus, width, height));
+      }
+
+      function renderSeriesSvg(series, config, focus, width = 960, height = 260) {
+        const svgWidth = Math.max(420, Math.round(width));
+        const svgHeight = Math.max(220, Math.round(height));
+        const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        svg.classList.add("chart-svg");
+        svg.setAttribute("viewBox", `0 0 ${svgWidth} ${svgHeight}`);
+        svg.setAttribute("role", "img");
+        svg.setAttribute("aria-label", `${grainLabel(focus?.granularity)} product analytics trend`);
+        svg.style.height = `${svgHeight}px`;
+
+        const maxValue = Math.max(
+          1,
+          ...series.flatMap((point) => config.map((item) => Number(point[item.key] || 0))),
+        );
+        const chart = {
+          left: 42,
+          top: 18,
+          right: 14,
+          bottom: 34,
+          width: Math.max(1, svgWidth - 56),
+          height: Math.max(1, svgHeight - 52),
+        };
+
+        appendSvgLine(svg, chart.left, chart.top + chart.height, chart.left + chart.width, chart.top + chart.height, "#dbe1e7");
+        appendSvgLine(svg, chart.left, chart.top, chart.left, chart.top + chart.height, "#dbe1e7");
+
+        if (!series.length) {
+          if (!state.analyticsPendingPanels.has("series")) {
+            appendSvgText(svg, svgWidth / 2, svgHeight / 2, "No trend data", "middle", "#5c6670");
+          }
+          return svg;
+        }
+
+        for (const item of config) {
+          const path = series
+            .map((point, index) => {
+              const x = chart.left + (series.length === 1 ? chart.width / 2 : (index / (series.length - 1)) * chart.width);
+              const y = chart.top + chart.height - (Number(point[item.key] || 0) / maxValue) * chart.height;
+              return `${index === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)}`;
+            })
+            .join(" ");
+          const line = document.createElementNS("http://www.w3.org/2000/svg", "path");
+          line.setAttribute("d", path);
+          line.setAttribute("fill", "none");
+          line.setAttribute("stroke", item.color);
+          line.setAttribute("stroke-width", "3");
+          line.setAttribute("stroke-linecap", "round");
+          line.setAttribute("stroke-linejoin", "round");
+          svg.appendChild(line);
+        }
+
+        appendSvgText(svg, chart.left, svgHeight - 14, series[0].bucket, "start", "#5c6670");
+        appendSvgText(svg, chart.left + chart.width, svgHeight - 14, series.at(-1).bucket, "end", "#5c6670");
+        appendSvgText(svg, chart.left - 8, chart.top + 4, formatNumber(maxValue), "end", "#5c6670");
+        appendSvgText(svg, chart.left - 8, chart.top + chart.height + 4, "0", "end", "#5c6670");
+        return svg;
+      }
+
+      function appendSvgLine(svg, x1, y1, x2, y2, color) {
+        const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+        line.setAttribute("x1", x1);
+        line.setAttribute("y1", y1);
+        line.setAttribute("x2", x2);
+        line.setAttribute("y2", y2);
+        line.setAttribute("stroke", color);
+        line.setAttribute("stroke-width", "1");
+        svg.appendChild(line);
+      }
+
+      function appendSvgText(svg, x, y, text, anchor, color) {
+        const label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        label.setAttribute("x", x);
+        label.setAttribute("y", y);
+        label.setAttribute("text-anchor", anchor);
+        label.setAttribute("fill", color);
+        label.setAttribute("font-size", "11");
+        label.setAttribute("font-family", "SFMono-Regular, ui-monospace, monospace");
+        label.textContent = text;
+        svg.appendChild(label);
+      }
+
+      function seriesConfig(charts = null) {
+        const focusMetric = charts?.focus?.metric || "";
+        const config = [
+          {
+            key: "focused_value",
+            ref: focusMetric,
+            label: charts?.focus?.metric_label || "Selected",
+            color: "#087a55",
+          },
+          { key: "event_count", ref: "events.event_count", label: "Events", color: "#5c6670" },
+          { key: "pageviews", ref: "pageviews.pageviews", label: "Pageviews", color: "#2d5f9a" },
+          { key: "session_count", ref: "sessions.session_count", label: "Sessions", color: "#9a6b16" },
+          { key: "recordings", ref: "events.snapshot_events", label: "Recordings", color: "#9d332b" },
+        ];
+        return config.filter((item, index) => index === 0 || item.ref !== focusMetric);
+      }
+
+      function grainLabel(granularity) {
+        if (granularity === "week") return "Weekly";
+        if (granularity === "month") return "Monthly";
+        return "Daily";
+      }
+
+      function formatNumber(value) {
+        return new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(value || 0);
+      }
+
+      function analyticsFocusFromCurrentForm() {
+        return {
+          metric: els.metric.value || "events.event_count",
+          dimension: els.dimension.value || "events.event_type",
+          granularity: els.granularity.value || "day",
+        };
+      }
+
+      function analyticsFocusFromParams(params) {
+        return {
+          metric: params.get("metric") || els.metric.value || "events.event_count",
+          dimension: params.get("dimension") || els.dimension.value || "events.event_type",
+          granularity: params.get("granularity") || els.granularity.value || "day",
+        };
+      }
+
+      function selectedOptionLabel(select, value) {
+        const option = [...select.options].find((item) => item.value === value);
+        return option?.textContent?.trim() || value || "-";
+      }
+
+      function analyticsMetricLabel(metricRef) {
+        const metric = state.charts?.summary?.find((item) => item.semantic_ref === metricRef);
+        return metric?.label || selectedOptionLabel(els.metric, metricRef);
+      }
+
+      function analyticsDimensionLabel(dimensionRef) {
+        return selectedOptionLabel(els.dimension, dimensionRef);
+      }
+
+      function analyticsDimensionTitle(dimensionRef) {
+        const titles = {
+          "events.event_type": "Events",
+          "events.browser": "Browsers",
+          "events.geo_country_code": "Countries",
+          "events.geo_region": "Regions",
+          "events.geo_city": "Cities",
+          "pageviews.pathname": "Pages",
+          "pageviews.host": "Domains",
+          "pageviews.referrer_domain": "Referring domains",
+          "pageviews.referrer": "Referrers",
+          "sessions.landing_path": "Landing paths",
+          "sessions.browser": "Session browsers",
+          "sessions.geo_country_code": "Session countries",
+          "sessions.geo_region": "Session regions",
+          "sessions.geo_city": "Session cities",
+        };
+        return titles[dimensionRef] || analyticsDimensionLabel(dimensionRef);
+      }
+
+      function semanticFilterEntries() {
+        return Object.entries(semanticFilters()).flatMap(([dimension, values]) =>
+          (values || []).map((value) => ({ dimension, value: normalizeFilterValue(value) })).filter((item) => item.value),
+        );
+      }
+
+      function semanticFilterSummary() {
+        const entries = semanticFilterEntries();
+        if (!entries.length) return "No filters";
+        if (entries.length === 1) {
+          const entry = entries[0];
+          return `${semanticFilterLabel(entry.dimension)}: ${entry.value}`;
+        }
+        return `${entries.length} filters`;
+      }
+
+      function analyticsQuerySubtitle(focus) {
+        const filters = semanticFilterSummary();
+        const pieces = [
+          analyticsMetricLabel(focus.metric),
+          `Breakdown: ${analyticsDimensionLabel(focus.dimension)}`,
+          `${grainLabel(focus.granularity)} trend`,
+        ];
+        if (filters !== "No filters") pieces.push(filters);
+        return pieces.join(" · ");
+      }
+
       function renderFacts(session) {
+        els.inspectorTitle.textContent = "Session context";
+        setFactLabels("User", "First seen", "Duration", "Events", "Chunks", "First URL");
         els.activeTitle.textContent = session?.session_id || "No session selected";
         els.activeSubtitle.textContent = session
           ? `${session.distinct_id} · ${formatDurationMs(session.duration_ms)} · ${session.event_count} rrweb events`
-          : "Search replay sessions or choose an analytics event.";
+          : "Search replay sessions or choose an event.";
         els.detailDistinct.textContent = session?.distinct_id || "-";
-        els.detailApiKey.textContent = session?.api_key || "-";
+        els.detailSecondary.textContent = session ? formatTime(session.first_seen) : "-";
         els.detailDuration.textContent = session ? formatDurationMs(session.duration_ms) : "-";
         els.detailEvents.textContent = session ? String(session.event_count) : "-";
         els.detailChunks.textContent = session ? String(session.chunk_count) : "-";
         els.detailUrl.textContent = session?.first_url || "-";
+      }
+
+      function renderAnalyticsFacts(charts) {
+        const focus = charts?.focus || analyticsFocusFromCurrentForm();
+        els.inspectorTitle.textContent = "Analytics inspector";
+        setFactLabels("Metric", "Breakdown", "Trend", "Rows", "Engine", "State");
+        els.detailDistinct.textContent = analyticsMetricLabel(focus.metric);
+        els.detailSecondary.textContent = analyticsDimensionLabel(focus.dimension);
+        els.detailDuration.textContent = grainLabel(focus.granularity);
+        els.detailEvents.textContent = String(analyticsBreakdownLimit);
+        els.detailChunks.textContent = "Sidemantic";
+        els.detailUrl.textContent = state.analyticsLoading ? "Updating" : "Ready";
+      }
+
+      function setFactLabels(user, secondary, duration, events, chunks, url) {
+        els.detailDistinctLabel.textContent = user;
+        els.detailSecondaryLabel.textContent = secondary;
+        els.detailDurationLabel.textContent = duration;
+        els.detailEventsLabel.textContent = events;
+        els.detailChunksLabel.textContent = chunks;
+        els.detailUrlLabel.textContent = url;
       }
 
       function renderActivity(activity) {
@@ -1874,6 +3304,27 @@
           main.append(strong, detail);
           row.append(time, main);
           els.activity.appendChild(row);
+        }
+        setDebugPayload();
+      }
+
+      function renderChartContext(selectedMetric = null) {
+        const rows = selectedMetric
+          ? [
+              ["Metric", selectedMetric.label, selectedMetric.semantic_ref],
+              ["Value", selectedMetric.display_value, "Current query"],
+            ]
+          : [];
+
+        els.timelineLabel.textContent = selectedMetric ? "Metric detail" : "Selection";
+        els.activity.innerHTML = "";
+        els.activityCount.textContent = String(rows.length);
+        if (!rows.length) {
+          renderTimelineEmpty("No selection", "");
+          return;
+        }
+        for (const row of rows) {
+          appendContextRow(row[0], row[1], row[2]);
         }
         setDebugPayload();
       }
@@ -1966,6 +3417,23 @@
         els.activity.appendChild(row);
       }
 
+      function appendContextRow(labelText, titleText, detailText) {
+        const row = document.createElement("div");
+        row.className = "timeline-row context-row";
+        const label = document.createElement("span");
+        label.className = "timeline-time";
+        label.textContent = labelText;
+        const main = document.createElement("span");
+        main.className = "timeline-main";
+        const strong = document.createElement("strong");
+        strong.textContent = titleText;
+        const detail = document.createElement("span");
+        detail.textContent = detailText;
+        main.append(strong, detail);
+        row.append(label, main);
+        els.activity.appendChild(row);
+      }
+
       function renderTimelineEmpty(title, body) {
         els.activity.innerHTML = "";
         const empty = document.createElement("div");
@@ -1974,7 +3442,8 @@
         strong.textContent = title;
         const span = document.createElement("span");
         span.textContent = body;
-        empty.append(strong, span);
+        empty.appendChild(strong);
+        if (body) empty.appendChild(span);
         els.activity.appendChild(empty);
         setDebugPayload();
       }
@@ -2069,6 +3538,23 @@
         state.playerResizeTimer = window.setTimeout(resizePlayer, 120);
       }
 
+      function resizeCharts() {
+        if (state.mode !== "overview" || !state.charts) return;
+        const canvas = els.player.querySelector(".chart-canvas");
+        if (!canvas) return;
+        renderSeriesIntoCanvas(
+          canvas,
+          state.charts.series || [],
+          seriesConfig(state.charts),
+          state.charts.focus,
+        );
+      }
+
+      function scheduleChartResize() {
+        window.clearTimeout(state.chartResizeTimer);
+        state.chartResizeTimer = window.setTimeout(resizeCharts, 120);
+      }
+
       function seekPlayer(anchorMs) {
         const offset = Math.max(0, Math.round(anchorMs || 0));
         window.setTimeout(() => {
@@ -2091,7 +3577,7 @@
         const params = paramsFromForm({ mode: "sessionLoad" });
         params.set("session_id", sessionId);
         if (atMs) params.set("at_ms", String(Math.round(atMs)));
-        history.replaceState(null, "", `${location.pathname}?${params.toString()}`);
+        replaceUrl(replayPath, params);
       }
 
       async function copyLink() {
@@ -2108,6 +3594,7 @@
         els.toggleRail.setAttribute("aria-pressed", String(collapsed));
         els.toggleRail.setAttribute("aria-expanded", String(!collapsed));
         window.requestAnimationFrame(schedulePlayerResize);
+        window.requestAnimationFrame(scheduleChartResize);
       }
 
       function setInspectorCollapsed(collapsed) {
@@ -2119,11 +3606,13 @@
         els.toggleInspector.setAttribute("aria-pressed", String(collapsed));
         els.toggleInspector.setAttribute("aria-expanded", String(!collapsed));
         window.requestAnimationFrame(schedulePlayerResize);
+        window.requestAnimationFrame(scheduleChartResize);
       }
 
       function setDebugPayload() {
         els.debugPayload.textContent = JSON.stringify(
           {
+            charts: state.charts,
             selectedSession: state.selectedSession,
             selectedEvent: state.selectedEvent,
             selectedFunnel: state.selectedFunnel,
@@ -2138,7 +3627,8 @@
 
       async function runSearch() {
         try {
-          if (state.mode === "sessions") await loadSessions();
+          if (state.mode === "overview") await loadCharts();
+          else if (state.mode === "sessions") await loadSessions();
           else if (state.mode === "events") await loadEvents();
           else if (state.mode === "funnels") await loadFunnels();
           else if (state.mode === "friction") await loadFriction();
@@ -2151,19 +3641,32 @@
 
       function switchMode(mode) {
         setMode(mode);
+        if (state.section === "replays") replaceReplayUrlFromForm(mode);
         runSearch();
+      }
+
+      function switchSection(section) {
+        if (section === state.section) return;
+        setMode(section === "analytics" ? "overview" : state.lastReplayMode || "sessions");
+        if (state.section === "analytics") requestAnalyticsSearch();
+        else {
+          replaceReplayUrlFromForm();
+          runSearch();
+        }
       }
 
       els.filters.addEventListener("submit", (event) => {
         event.preventDefault();
-        runSearch();
+        requestSearchForCurrentMode();
       });
+      els.replaySection.addEventListener("click", () => switchSection("replays"));
+      els.analyticsSection.addEventListener("click", () => switchSection("analytics"));
       els.sessionMode.addEventListener("click", () => switchMode("sessions"));
       els.eventMode.addEventListener("click", () => switchMode("events"));
       els.funnelMode.addEventListener("click", () => switchMode("funnels"));
       els.frictionMode.addEventListener("click", () => switchMode("friction"));
       els.personMode.addEventListener("click", () => switchMode("person"));
-      els.reload.addEventListener("click", runSearch);
+      els.reload.addEventListener("click", requestSearchForCurrentMode);
       els.toggleRail.addEventListener("click", () => setRailCollapsed(!state.railCollapsed));
       els.toggleInspector.addEventListener("click", () =>
         setInspectorCollapsed(!state.inspectorCollapsed),
@@ -2176,10 +3679,14 @@
       els.copyLink.addEventListener("click", () => copyLink().catch(() => setStatus("copy failed")));
       els.debugToggle.addEventListener("click", () => els.debug.classList.toggle("is-open"));
       els.clear.addEventListener("click", () => {
+        cancelAnalyticsRequests();
         els.filters.reset();
         document.getElementById("limit").value = "100";
+        writeSemanticFilters({});
         setFunnelSteps(defaultFunnelSteps.join(","));
         setSignal("");
+        syncAnalyticsDimensions();
+        state.charts = null;
         state.sessions = [];
         state.events = [];
         state.funnels = [];
@@ -2196,15 +3703,22 @@
         renderActivity([]);
         setStatus("idle");
         showMessage("empty", "Ready", "Load sessions, then select a recording to replay.");
-        history.replaceState(null, "", location.pathname);
+        replaceUrl(state.section === "analytics" ? analyticsPath : replayPath, new URLSearchParams());
       });
 
       function bootFromUrl() {
         const params = new URLSearchParams(location.search);
+        const bootingAnalytics =
+          location.pathname === "/" ||
+          location.pathname.replace(/\/$/, "") === analyticsPath ||
+          params.get("section") === "analytics";
+        const bootingReplay = location.pathname.replace(/\/$/, "") === replayPath;
         for (const [key, value] of params.entries()) {
-          if (key === "at_ms" || key === "mode") continue;
+          if (key === "at_ms" || key === "mode" || key === "section") continue;
           setField(key, value);
         }
+        syncAnalyticsDimensions();
+        renderSemanticFilters();
         setFunnelSteps(params.get("steps") || document.getElementById("steps").value);
         setSignal(params.get("signal") || "");
         const sessionId = params.get("session_id");
@@ -2214,21 +3728,36 @@
           loadSessions({ silent: true, keepSelection: true })
             .then(() => loadSession(sessionId, Number.isFinite(atMs) ? atMs : 0))
             .catch((error) => showMessage("error", "Replay unavailable", error.message));
+        } else if (bootingAnalytics) {
+          setMode("overview");
+          replaceAnalyticsUrlFromForm();
+          runSearch();
         } else if (modes[params.get("mode")]) {
           setMode(params.get("mode"));
           runSearch();
-        } else {
+        } else if (bootingReplay) {
           setMode("sessions");
           renderActivity([]);
+        } else {
+          setMode("overview");
+          replaceAnalyticsUrlFromForm();
+          runSearch();
         }
       }
 
-      window.addEventListener("resize", schedulePlayerResize);
+      window.addEventListener("resize", () => {
+        schedulePlayerResize();
+        scheduleChartResize();
+      });
       if (window.ResizeObserver) {
-        new ResizeObserver(schedulePlayerResize).observe(els.player.parentElement);
+        new ResizeObserver(() => {
+          schedulePlayerResize();
+          scheduleChartResize();
+        }).observe(els.player.parentElement);
       }
 
       initModeControls();
+      initAnalyticsControls();
       bootFromUrl();
     </script>
   </body>

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -2470,7 +2470,7 @@
         const query = params?.toString();
         const response = await fetch(query ? `${path}?${query}` : path, options);
         const body = await response.json();
-        if (!response.ok) throw new Error(body.error || "Replay request failed.");
+        if (!response.ok) throw new Error(body.error || "Request failed.");
         return body;
       }
 
@@ -3638,7 +3638,11 @@
           else await loadPerson();
         } catch (error) {
           setStatus("error");
-          showMessage("error", "Replay unavailable", error.message);
+          showMessage(
+            "error",
+            state.mode === "overview" ? "Analytics unavailable" : "Replay unavailable",
+            error.message,
+          );
         }
       }
 

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -1050,6 +1050,7 @@
       .breakdown-grid .chart-panel {
         border-bottom: 0;
         background: var(--surface);
+        overflow: visible;
       }
 
       .breakdown-grid .chart-panel:first-child {
@@ -1071,6 +1072,17 @@
 
       .breakdown-grid .chart-panel:nth-child(9) {
         border-right: 1px solid var(--line);
+      }
+
+      .breakdown-grid .chart-panel:nth-child(9)::before {
+        position: absolute;
+        top: -1px;
+        left: 100%;
+        width: 200%;
+        height: 1px;
+        background: var(--line);
+        content: "";
+        pointer-events: none;
       }
 
       .breakdown-row {
@@ -1364,6 +1376,10 @@
 
         .breakdown-grid .chart-panel:nth-child(9) {
           border-right: 0;
+        }
+
+        .breakdown-grid .chart-panel:nth-child(9)::before {
+          display: none;
         }
       }
     </style>

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -1048,13 +1048,16 @@
       }
 
       .breakdown-grid .chart-panel {
-        border-top: 1px solid var(--line);
         border-bottom: 0;
         background: var(--surface);
       }
 
       .breakdown-grid .chart-panel:first-child {
         grid-column: span 2;
+      }
+
+      .breakdown-grid .chart-panel:nth-child(n + 3) {
+        border-top: 1px solid var(--line);
       }
 
       .breakdown-grid .chart-panel:nth-child(2),
@@ -1064,6 +1067,10 @@
       .breakdown-grid .chart-panel:nth-child(8),
       .breakdown-grid .chart-panel:nth-child(10) {
         border-left: 1px solid var(--line);
+      }
+
+      .breakdown-grid .chart-panel:nth-child(9) {
+        border-right: 1px solid var(--line);
       }
 
       .breakdown-row {
@@ -1342,6 +1349,10 @@
           grid-column: span 1;
         }
 
+        .breakdown-grid .chart-panel:nth-child(n + 2) {
+          border-top: 1px solid var(--line);
+        }
+
         .breakdown-grid .chart-panel:nth-child(2),
         .breakdown-grid .chart-panel:nth-child(4),
         .breakdown-grid .chart-panel:nth-child(5),
@@ -1349,6 +1360,10 @@
         .breakdown-grid .chart-panel:nth-child(8),
         .breakdown-grid .chart-panel:nth-child(10) {
           border-left: 0;
+        }
+
+        .breakdown-grid .chart-panel:nth-child(9) {
+          border-right: 0;
         }
       }
     </style>

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Hogflare Replay Explorer</title>
+    <title>Hogflare</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/rrweb-player@latest/dist/style.css" />
     <script src="https://cdn.jsdelivr.net/npm/rrweb-player@latest/dist/index.js"></script>
     <style>

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -1426,11 +1426,11 @@
             <div class="date-range" role="group" aria-labelledby="dateRangeLabel">
               <span class="label date-range-label" id="dateRangeLabel">Date range</span>
               <div class="date-presets" aria-label="Date range presets">
-                <button class="preset-button" type="button" data-date-preset="today">Today</button>
-                <button class="preset-button" type="button" data-date-preset="24h">Last 24h</button>
-                <button class="preset-button" type="button" data-date-preset="7d">Last 7d</button>
-                <button class="preset-button" type="button" data-date-preset="30d">Last 30d</button>
-                <button class="preset-button" type="button" data-date-preset="clear">Clear dates</button>
+                <button class="preset-button" type="button" data-date-preset="today" aria-pressed="false">Today</button>
+                <button class="preset-button" type="button" data-date-preset="24h" aria-pressed="false">Last 24h</button>
+                <button class="preset-button" type="button" data-date-preset="7d" aria-pressed="false">Last 7d</button>
+                <button class="preset-button" type="button" data-date-preset="30d" aria-pressed="true">Last 30d</button>
+                <button class="preset-button" type="button" data-date-preset="clear" aria-pressed="false">Clear dates</button>
               </div>
               <div class="date-inputs">
                 <label class="date-field" for="dateFrom">
@@ -1532,7 +1532,8 @@
                 <div class="field wide">
                   <label class="label" for="granularity">Trend grain</label>
                   <select id="granularity" name="granularity">
-                    <option value="day">Day</option>
+                    <option value="hour">Hour</option>
+                    <option value="day" selected>Day</option>
                     <option value="week">Week</option>
                     <option value="month">Month</option>
                   </select>
@@ -1571,7 +1572,7 @@
             </div>
             <div class="actions">
               <button class="button" id="submitButton" type="submit" data-section="replays">Search</button>
-              <button class="button secondary" id="clear" type="button">Clear</button>
+              <button class="button secondary" id="clear" type="button" data-section="replays">Clear</button>
             </div>
           </form>
 
@@ -1804,6 +1805,8 @@
         modeOptions: document.getElementById("modeOptions"),
         funnelStepControls: document.getElementById("funnelStepControls"),
         signalChoices: document.getElementById("signalChoices"),
+        dateFrom: document.getElementById("dateFrom"),
+        dateTo: document.getElementById("dateTo"),
         datePresets: document.querySelector(".date-presets"),
         metric: document.getElementById("metric"),
         dimension: document.getElementById("dimension"),
@@ -1938,6 +1941,7 @@
         "Demo Requested",
       ];
       const defaultFunnelSteps = ["Viewed Pricing", "Checkout Started", ""];
+      const defaultAnalyticsDatePreset = "30d";
       const analyticsPath = "/analytics";
       const replayPath = "/replay";
 
@@ -2007,8 +2011,13 @@
       }
 
       function setDateRange(from, to) {
-        document.getElementById("dateFrom").value = from ? isoToDateInput(from) : "";
-        document.getElementById("dateTo").value = to ? isoToDateInput(to) : "";
+        els.dateFrom.value = from ? isoToDateInput(from) : "";
+        els.dateTo.value = to ? isoToDateInput(to) : "";
+      }
+
+      function dateFromInput(value) {
+        const date = new Date(value);
+        return Number.isFinite(date.getTime()) ? date : null;
       }
 
       function applyDatePreset(preset) {
@@ -2032,13 +2041,63 @@
           return;
         }
         setDateRange(from, to);
+        setGranularityForDatePreset(preset);
         setDatePresetState(preset);
         requestSearchForCurrentMode();
       }
 
       function setDatePresetState(preset) {
         for (const button of els.datePresets.querySelectorAll("[data-date-preset]")) {
-          button.classList.toggle("is-selected", button.dataset.datePreset === preset);
+          const selected = button.dataset.datePreset === preset;
+          button.classList.toggle("is-selected", selected);
+          button.setAttribute("aria-pressed", selected ? "true" : "false");
+        }
+      }
+
+      function setGranularityForDatePreset(preset) {
+        if (state.mode !== "overview") return;
+        if (preset === "24h") {
+          els.granularity.value = "hour";
+        } else if ((preset === "7d" || preset === "30d") && els.granularity.value === "hour") {
+          els.granularity.value = "day";
+        }
+      }
+
+      function ensureDefaultAnalyticsDateRange() {
+        if (els.dateFrom.value || els.dateTo.value) {
+          syncDatePresetFromInputs();
+          return;
+        }
+        const to = new Date();
+        const from = new Date(to);
+        from.setDate(from.getDate() - 30);
+        setDateRange(from, to);
+        setGranularityForDatePreset(defaultAnalyticsDatePreset);
+        setDatePresetState(defaultAnalyticsDatePreset);
+      }
+
+      function syncDatePresetFromInputs() {
+        const from = dateFromInput(els.dateFrom.value);
+        const to = dateFromInput(els.dateTo.value);
+        if (!from || !to) {
+          setDatePresetState("");
+          return;
+        }
+        const minute = 60 * 1000;
+        const tolerance = 5 * minute;
+        const elapsed = to.getTime() - from.getTime();
+        const startOfDay = new Date(to);
+        startOfDay.setHours(0, 0, 0, 0);
+        if (Math.abs(from.getTime() - startOfDay.getTime()) <= tolerance) {
+          setDatePresetState("today");
+        } else if (Math.abs(elapsed - 24 * 60 * minute) <= tolerance) {
+          setDatePresetState("24h");
+        } else if (Math.abs(elapsed - 7 * 24 * 60 * minute) <= tolerance) {
+          setDatePresetState("7d");
+        } else if (Math.abs(elapsed - 30 * 24 * 60 * minute) <= tolerance) {
+          setDatePresetState("30d");
+        } else {
+          setDatePresetState("");
         }
       }
 
@@ -2243,9 +2302,6 @@
           button.setAttribute("aria-selected", mode === key ? "true" : "false");
         }
         els.submitButton.textContent = "Search";
-        els.clear.textContent = state.section === "analytics" ? "Reset" : "Clear";
-        els.clear.classList.toggle("secondary", state.section !== "analytics");
-        els.clear.classList.toggle("subtle", state.section === "analytics");
         els.resultsLabel.textContent = modes[mode].label;
         els.resultControls.classList.toggle("is-hidden", state.section === "analytics");
         let hasModeOptions = false;
@@ -3170,6 +3226,7 @@
       }
 
       function grainLabel(granularity) {
+        if (granularity === "hour") return "Hourly";
         if (granularity === "week") return "Weekly";
         if (granularity === "month") return "Monthly";
         return "Daily";
@@ -3738,6 +3795,9 @@
         if (!button) return;
         applyDatePreset(button.dataset.datePreset);
       });
+      for (const input of [els.dateFrom, els.dateTo]) {
+        input.addEventListener("change", syncDatePresetFromInputs);
+      }
       els.copyLink.addEventListener("click", () => copyLink().catch(() => setStatus("copy failed")));
       els.debugToggle.addEventListener("click", () => els.debug.classList.toggle("is-open"));
       els.clear.addEventListener("click", () => {
@@ -3762,6 +3822,7 @@
         state.selectedPersonItem = null;
         state.sessionPayload = null;
         if (wasAnalytics) {
+          ensureDefaultAnalyticsDateRange();
           requestAnalyticsSearch();
         } else {
           renderResults();
@@ -3785,6 +3846,8 @@
           setField(key, value);
         }
         syncAnalyticsDimensions();
+        if (bootingAnalytics) ensureDefaultAnalyticsDateRange();
+        else syncDatePresetFromInputs();
         renderSemanticFilters();
         setFunnelSteps(params.get("steps") || document.getElementById("steps").value);
         setSignal(params.get("signal") || "");

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -1516,7 +1516,7 @@
               <input id="limit" name="limit" inputmode="numeric" value="100" />
             </div>
             <div class="actions">
-              <button class="button" id="submitButton" type="submit">Search</button>
+              <button class="button" id="submitButton" type="submit" data-section="replays">Search</button>
               <button class="button secondary" id="clear" type="button">Clear</button>
             </div>
           </form>
@@ -2187,7 +2187,10 @@
         ]) {
           button.setAttribute("aria-selected", mode === key ? "true" : "false");
         }
-        els.submitButton.textContent = state.section === "analytics" ? "Analyze" : "Search";
+        els.submitButton.textContent = "Search";
+        els.clear.textContent = state.section === "analytics" ? "Reset" : "Clear";
+        els.clear.classList.toggle("secondary", state.section !== "analytics");
+        els.clear.classList.toggle("subtle", state.section === "analytics");
         els.resultsLabel.textContent = modes[mode].label;
         els.resultControls.classList.toggle("is-hidden", state.section === "analytics");
         let hasModeOptions = false;
@@ -3679,6 +3682,7 @@
       els.copyLink.addEventListener("click", () => copyLink().catch(() => setStatus("copy failed")));
       els.debugToggle.addEventListener("click", () => els.debug.classList.toggle("is-open"));
       els.clear.addEventListener("click", () => {
+        const wasAnalytics = state.section === "analytics";
         cancelAnalyticsRequests();
         els.filters.reset();
         document.getElementById("limit").value = "100";
@@ -3698,12 +3702,16 @@
         state.selectedFriction = null;
         state.selectedPersonItem = null;
         state.sessionPayload = null;
-        renderResults();
-        renderFacts(null);
-        renderActivity([]);
-        setStatus("idle");
-        showMessage("empty", "Ready", "Load sessions, then select a recording to replay.");
-        replaceUrl(state.section === "analytics" ? analyticsPath : replayPath, new URLSearchParams());
+        if (wasAnalytics) {
+          requestAnalyticsSearch();
+        } else {
+          renderResults();
+          renderFacts(null);
+          renderActivity([]);
+          setStatus("idle");
+          showMessage("empty", "Ready", "Load sessions, then select a recording to replay.");
+          replaceUrl(replayPath, new URLSearchParams());
+        }
       });
 
       function bootFromUrl() {

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -60,6 +60,7 @@
         display: grid;
         --rail-track: minmax(320px, 380px);
         --inspector-track: minmax(330px, 420px);
+        --analytics-nav-width: 320px;
         grid-template-columns: var(--rail-track) minmax(560px, 1fr) var(--inspector-track);
         height: 100vh;
         min-height: 0;
@@ -130,6 +131,45 @@
         z-index: 20;
       }
 
+      .app.analytics-mode {
+        --rail-track: 0px;
+      }
+
+      .app.analytics-mode .rail {
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 30;
+        width: var(--analytics-nav-width);
+        height: 56px;
+        min-height: 56px;
+        border-right: 1px solid var(--line);
+        border-bottom: 1px solid var(--line);
+        background: var(--surface);
+        pointer-events: auto;
+      }
+
+      .app.analytics-mode .rail-content {
+        display: block;
+      }
+
+      .app.analytics-mode .topbar {
+        border-bottom: 0;
+      }
+
+      .app.analytics-mode .rail-body,
+      .app.analytics-mode .rail-dock {
+        display: none;
+      }
+
+      .app.analytics-mode .stage-head {
+        padding-left: calc(var(--analytics-nav-width) + 16px);
+      }
+
+      .app.analytics-mode .stage {
+        grid-column: 1 / -1;
+      }
+
       .topbar,
       .stage-head,
       .inspector-head {
@@ -162,15 +202,15 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: 34px;
-        height: 40px;
+        width: 28px;
+        height: 32px;
         color: var(--ink);
       }
 
       .brand-mark svg {
         display: block;
-        width: 34px;
-        height: 40px;
+        width: 28px;
+        height: 32px;
       }
 
       h1,
@@ -523,7 +563,12 @@
 
       .field input:focus,
       .field select:focus,
-      .date-field input:focus {
+      .date-field input:focus,
+      .analytics-filter-popover input:focus,
+      .analytics-filter-popover select:focus,
+      .analytics-date-popover input:focus,
+      .analytics-date-popover select:focus,
+      .analytics-grain-select:focus {
         border-color: var(--accent);
         box-shadow: 0 0 0 2px var(--accent-soft);
       }
@@ -567,7 +612,8 @@
       .preset-button:disabled,
       .mode-button:disabled,
       .section-button:disabled,
-      .chip-button:disabled {
+      .chip-button:disabled,
+      .analytics-filter-trigger:disabled {
         cursor: wait;
         opacity: 0.56;
         transform: none !important;
@@ -665,6 +711,10 @@
         display: none;
       }
 
+      .app.inspector-unavailable .inspector-dock {
+        display: none;
+      }
+
       @media (hover: hover) {
         .button:hover {
           background: #2a2d2a;
@@ -675,7 +725,9 @@
         .preset-button:hover,
         .row-button:hover,
         .timeline-row:hover,
-        .panel-toggle:hover {
+        .panel-toggle:hover,
+        .analytics-filter-trigger:hover,
+        .analytics-date-trigger:hover {
           background: var(--surface-soft);
           border-color: var(--line-strong);
           color: var(--ink);
@@ -827,16 +879,207 @@
 
       .chart-overview {
         display: grid;
-        grid-template-rows: auto minmax(286px, 0.85fr) auto;
+        grid-template-rows: auto auto minmax(286px, 0.85fr) auto;
         gap: 0;
         min-height: 100%;
-        max-width: 100%;
+        width: calc(100% + 2px);
+        max-width: none;
+        margin-inline: -1px;
         overflow: auto;
+      }
+
+      .analytics-control-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        min-width: 0;
+        gap: 12px;
+        min-height: 44px;
+        border-bottom: 1px solid var(--line);
+        background: var(--surface);
+        padding: 7px 12px;
+      }
+
+      .analytics-control-left,
+      .analytics-control-right,
+      .analytics-active-filters {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+        gap: 6px;
+      }
+
+      .analytics-control-left {
+        flex: 1 1 auto;
+        flex-wrap: wrap;
+      }
+
+      .analytics-control-right {
+        flex: 0 0 auto;
+        margin-left: auto;
+      }
+
+      .analytics-active-filters {
+        flex-wrap: wrap;
+      }
+
+      .analytics-filter-menu,
+      .analytics-date-menu {
+        position: relative;
+        flex: 0 0 auto;
+      }
+
+      .analytics-filter-menu summary,
+      .analytics-date-menu summary {
+        list-style: none;
+      }
+
+      .analytics-filter-menu summary::-webkit-details-marker,
+      .analytics-date-menu summary::-webkit-details-marker {
+        display: none;
+      }
+
+      .analytics-filter-trigger,
+      .analytics-date-trigger {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        height: 30px;
+        border: 0;
+        border-radius: 0;
+        background: transparent;
+        color: var(--muted);
+        transition:
+          color 140ms ease,
+          transform 140ms ease;
+      }
+
+      .analytics-filter-trigger {
+        width: 30px;
+      }
+
+      .analytics-filter-trigger svg {
+        display: block;
+        width: 18px;
+        height: 18px;
+        stroke-width: 1.9;
+      }
+
+      .analytics-date-trigger {
+        gap: 8px;
+        min-width: 0;
+        padding: 0;
+        color: var(--ink);
+        font-family: var(--mono);
+        font-size: 12px;
+        font-weight: 720;
+      }
+
+      .analytics-date-trigger svg {
+        display: block;
+        width: 13px;
+        height: 13px;
+        color: var(--muted);
+        stroke-width: 2;
+      }
+
+      .analytics-filter-menu[open] .analytics-filter-trigger,
+      .analytics-date-menu[open] .analytics-date-trigger {
+        color: var(--ink);
+      }
+
+      .analytics-filter-popover,
+      .analytics-date-popover {
+        position: absolute;
+        top: calc(100% + 6px);
+        right: 0;
+        z-index: 50;
+        display: grid;
+        gap: 10px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: var(--surface);
+        box-shadow: 0 14px 34px rgba(16, 24, 40, 0.14);
+        padding: 10px;
+      }
+
+      .analytics-filter-popover {
+        width: 286px;
+        right: auto;
+        left: 0;
+      }
+
+      .analytics-date-popover {
+        width: 360px;
+      }
+
+      .analytics-filter-popover label {
+        display: grid;
+        gap: 5px;
+      }
+
+      .analytics-filter-popover input,
+      .analytics-filter-popover select,
+      .analytics-date-popover input,
+      .analytics-date-popover select,
+      .analytics-grain-select {
+        height: 30px;
+        min-width: 0;
+        border: 1px solid var(--line);
+        border-radius: 5px;
+        background: var(--surface);
+        color: var(--ink);
+        font: inherit;
+        font-size: 12px;
+        outline: none;
+        padding: 0 8px;
+      }
+
+      .analytics-filter-popover input,
+      .analytics-filter-popover select,
+      .analytics-date-popover input,
+      .analytics-date-popover select {
+        width: 100%;
+      }
+
+      .analytics-date-presets {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 6px;
+      }
+
+      .analytics-date-option {
+        justify-content: flex-start;
+        width: 100%;
+        height: 30px;
+        text-align: left;
+      }
+
+      .analytics-custom-range {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+        border-top: 1px solid var(--line);
+        padding-top: 10px;
+      }
+
+      .analytics-custom-range label {
+        display: grid;
+        gap: 5px;
+      }
+
+      .analytics-date-actions {
+        display: flex;
+        justify-content: flex-end;
+      }
+
+      .analytics-grain-select {
+        width: 100%;
       }
 
       .metric-grid {
         display: grid;
-        grid-template-columns: repeat(6, minmax(0, 1fr));
+        grid-template-columns: repeat(5, minmax(0, 1fr));
         border-bottom: 1px solid var(--line);
       }
 
@@ -855,21 +1098,22 @@
         text-align: left;
       }
 
+      .metric-card.is-selectable {
+        cursor: pointer;
+      }
+
       .metric-card.is-skeleton {
         cursor: default;
         pointer-events: none;
       }
 
-      .metric-card:last-child {
-        border-right: 0;
-      }
-
       .metric-card.is-selected {
         background: var(--surface-soft);
+        box-shadow: inset 0 -2px 0 var(--accent);
       }
 
-      .metric-card.is-selected {
-        box-shadow: inset 0 -2px 0 var(--accent);
+      .metric-card:last-child {
+        border-right: 0;
       }
 
       .metric-card:focus-visible,
@@ -912,7 +1156,6 @@
         min-height: 0;
         min-width: 0;
         overflow: hidden;
-        border-bottom: 1px solid var(--line);
       }
 
       .chart-panel-head {
@@ -982,7 +1225,8 @@
         grid-auto-flow: dense;
         grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
         background: var(--surface);
-        border-bottom: 1px solid var(--line);
+        overflow: hidden;
+        padding: 1px 0 0 1px;
       }
 
       .breakdown-list {
@@ -1046,41 +1290,11 @@
       }
 
       .breakdown-grid .chart-panel {
-        border-bottom: 0;
+        box-sizing: border-box;
+        border: 1px solid var(--line);
         background: var(--surface);
+        margin: -1px 0 0 -1px;
         overflow: hidden;
-      }
-
-      .breakdown-grid .chart-panel:first-child {
-        grid-column: span 2;
-      }
-
-      .breakdown-grid .chart-panel:nth-child(n + 3) {
-        border-top: 1px solid var(--line);
-      }
-
-      .breakdown-grid .chart-panel:nth-child(2),
-      .breakdown-grid .chart-panel:nth-child(4),
-      .breakdown-grid .chart-panel:nth-child(5),
-      .breakdown-grid .chart-panel:nth-child(7),
-      .breakdown-grid .chart-panel:nth-child(8),
-      .breakdown-grid .chart-panel:nth-child(10) {
-        border-left: 1px solid var(--line);
-      }
-
-      .breakdown-grid .chart-panel:nth-child(9) {
-        border-right: 1px solid var(--line);
-      }
-
-      .breakdown-grid .chart-panel:nth-child(9)::before {
-        position: absolute;
-        top: -1px;
-        left: 100%;
-        width: 200%;
-        height: 1px;
-        background: var(--line);
-        content: "";
-        pointer-events: none;
       }
 
       .breakdown-row {
@@ -1300,6 +1514,10 @@
           --rail-track: 0px;
         }
 
+        .app.analytics-mode {
+          --rail-track: 0px;
+        }
+
         .app.inspector-collapsed {
           --inspector-track: minmax(0, 1fr);
         }
@@ -1333,6 +1551,20 @@
           border-bottom: 1px solid var(--line);
         }
 
+        .app.analytics-mode {
+          --analytics-nav-width: 100vw;
+        }
+
+        .app.analytics-mode .rail {
+          width: 100vw;
+          border-right: 0;
+        }
+
+        .app.analytics-mode .stage-head {
+          height: auto;
+          padding: 64px 16px 8px;
+        }
+
         .filters {
           grid-template-columns: 1fr;
         }
@@ -1351,35 +1583,21 @@
           width: 100%;
         }
 
+        .analytics-control-bar,
+        .analytics-control-right {
+          align-items: flex-start;
+          flex-direction: column;
+        }
+
+        .analytics-control-right {
+          margin-left: 0;
+        }
+
         .metric-grid,
         .breakdown-grid {
           grid-template-columns: 1fr;
         }
 
-        .breakdown-grid .chart-panel:first-child {
-          grid-column: span 1;
-        }
-
-        .breakdown-grid .chart-panel:nth-child(n + 2) {
-          border-top: 1px solid var(--line);
-        }
-
-        .breakdown-grid .chart-panel:nth-child(2),
-        .breakdown-grid .chart-panel:nth-child(4),
-        .breakdown-grid .chart-panel:nth-child(5),
-        .breakdown-grid .chart-panel:nth-child(7),
-        .breakdown-grid .chart-panel:nth-child(8),
-        .breakdown-grid .chart-panel:nth-child(10) {
-          border-left: 0;
-        }
-
-        .breakdown-grid .chart-panel:nth-child(9) {
-          border-right: 0;
-        }
-
-        .breakdown-grid .chart-panel:nth-child(9)::before {
-          display: none;
-        }
       }
     </style>
   </head>
@@ -1390,22 +1608,11 @@
           <header class="topbar">
             <div class="topbar-primary">
               <span class="brand-mark" aria-label="Hogflare" role="img">
-                <svg viewBox="0 0 64 72" aria-hidden="true" fill="none" stroke="currentColor">
+                <svg viewBox="0 0 733 868" aria-hidden="true" focusable="false">
                   <path
-                    d="M12 54c-5-10-4-28 5-39C24 6 38 5 48 13c8 7 11 20 7 31-3 10-11 17-23 17-9 0-16-2-20-7Z"
-                    stroke-width="4"
-                    stroke-linejoin="round"
+                    fill="currentColor"
+                    d="M253 19 L253 24 L260 30 L259 32 L253 33 L250 36 L231 43 L209 56 L187 72 L176 67 L170 67 L169 73 L180 78 L166 91 L156 88 L142 89 L141 92 L143 94 L156 96 L159 99 L145 113 L130 133 L115 157 L113 164 L103 181 L87 230 L82 262 L62 271 L53 279 L53 282 L57 282 L69 276 L78 274 L75 293 L62 300 L55 307 L55 311 L59 311 L70 304 L72 305 L63 341 L60 361 L58 364 L58 370 L54 381 L54 387 L47 410 L46 421 L44 423 L42 438 L39 444 L39 452 L31 479 L29 496 L27 498 L16 550 L14 552 L13 562 L11 565 L7 593 L4 599 L0 644 L6 680 L9 681 L12 686 L12 691 L14 692 L16 701 L24 719 L35 737 L48 753 L59 764 L87 785 L115 797 L120 801 L142 807 L170 810 L354 809 L356 813 L355 825 L357 826 L356 840 L361 853 L373 861 L393 865 L413 864 L426 856 L426 844 L428 843 L424 834 L422 815 L425 809 L479 809 L481 812 L482 824 L480 835 L483 836 L481 841 L483 842 L490 857 L496 861 L517 867 L541 867 L550 861 L554 851 L554 842 L549 817 L550 810 L564 808 L577 809 L616 800 L627 796 L634 790 L639 789 L643 785 L655 779 L688 749 L699 734 L713 709 L716 698 L719 696 L722 682 L726 681 L728 677 L732 649 L730 609 L723 589 L718 562 L716 561 L713 541 L708 528 L704 503 L701 499 L696 471 L691 458 L691 452 L670 368 L666 344 L657 314 L654 294 L652 292 L649 275 L647 273 L647 265 L643 257 L645 252 L663 245 L677 234 L688 222 L699 201 L706 169 L702 125 L710 105 L709 92 L705 86 L690 78 L668 74 L646 74 L625 78 L604 86 L574 107 L553 85 L554 72 L552 69 L547 71 L546 77 L544 78 L530 67 L530 59 L526 47 L522 47 L522 59 L520 60 L493 43 L462 29 L424 18 L398 14 L396 9 L388 0 L384 2 L387 13 L371 11 L332 13 L301 18 L299 20 L268 27 L257 19 Z"
                   />
-                  <path d="M19 18 13 8M29 12 27 3M42 14 45 5" stroke-width="4" stroke-linecap="round" />
-                  <path d="M24 25c-4-3-9-2-11 3M43 25c4-4 10-3 12 2" stroke-width="4" stroke-linecap="round" />
-                  <path
-                    d="M23 42c3-5 15-6 20-1 3 3 2 8-2 11-6 4-17 3-21-1-3-3-1-7 3-9Z"
-                    stroke-width="4"
-                    stroke-linejoin="round"
-                  />
-                  <path d="M27 44v5M37 44v5" stroke-width="4" stroke-linecap="round" />
-                  <path d="M24 35h.1M42 35h.1" stroke-width="5" stroke-linecap="round" />
-                  <path d="M16 60v6M45 59v7" stroke-width="4" stroke-linecap="round" />
                 </svg>
               </span>
               <nav class="section-switch" aria-label="Viewer section">
@@ -1427,9 +1634,15 @@
               <div class="date-presets" aria-label="Date range presets">
                 <button class="preset-button" type="button" data-date-preset="today" aria-pressed="false">Today</button>
                 <button class="preset-button" type="button" data-date-preset="24h" aria-pressed="false">Last 24h</button>
+                <button class="preset-button" type="button" data-date-preset="72h" aria-pressed="false">Last 72h</button>
                 <button class="preset-button" type="button" data-date-preset="7d" aria-pressed="false">Last 7d</button>
+                <button class="preset-button" type="button" data-date-preset="14d" aria-pressed="false">Last 14d</button>
                 <button class="preset-button" type="button" data-date-preset="30d" aria-pressed="true">Last 30d</button>
-                <button class="preset-button" type="button" data-date-preset="clear" aria-pressed="false">Clear dates</button>
+                <button class="preset-button" type="button" data-date-preset="quarter" aria-pressed="false">Quarter</button>
+                <button class="preset-button" type="button" data-date-preset="year" aria-pressed="false">Year</button>
+                <button class="preset-button" type="button" data-date-preset="2y" aria-pressed="false">2y</button>
+                <button class="preset-button" type="button" data-date-preset="5y" aria-pressed="false">5y</button>
+                <button class="preset-button" type="button" data-date-preset="max" aria-pressed="false">Max</button>
               </div>
               <div class="date-inputs">
                 <label class="date-field" for="dateFrom">
@@ -1440,6 +1653,15 @@
                   <span>To</span>
                   <input id="dateTo" name="date_to" type="datetime-local" autocomplete="off" step="60" />
                 </label>
+              </div>
+              <div class="field wide" data-section="analytics">
+                <label class="label" for="granularity">Date grain</label>
+                <select id="granularity" name="granularity">
+                  <option value="hour">Hour</option>
+                  <option value="day" selected>Day</option>
+                  <option value="week">Week</option>
+                  <option value="month">Month</option>
+                </select>
               </div>
             </div>
             <div class="field" data-section="replays">
@@ -1466,7 +1688,6 @@
                     <optgroup label="Events">
                       <option value="events.event_count">Events</option>
                       <option value="events.unique_users">Users</option>
-                      <option value="events.snapshot_events">Replay chunks</option>
                     </optgroup>
                     <optgroup label="Pageviews">
                       <option value="pageviews.pageviews">Pageviews</option>
@@ -1477,66 +1698,7 @@
                     </optgroup>
                   </select>
                 </div>
-                <div class="field wide">
-                  <label class="label" for="dimension">Breakdown</label>
-                  <select id="dimension" name="dimension">
-                    <optgroup label="Events">
-                      <option value="events.event_type" data-model="events">Event</option>
-                      <option value="events.browser" data-model="events">Browser</option>
-                      <option value="events.os" data-model="events">OS</option>
-                      <option value="events.device_type" data-model="events">Device</option>
-                      <option value="events.host" data-model="events">Host</option>
-                      <option value="events.referrer_domain" data-model="events">Referring domain</option>
-                      <option value="events.referrer" data-model="events">Referrer</option>
-                      <option value="events.geo_country_code" data-model="events">Country</option>
-                      <option value="events.geo_region" data-model="events">Region</option>
-                      <option value="events.geo_city" data-model="events">City</option>
-                      <option value="events.geo_timezone" data-model="events">Timezone</option>
-                      <option value="events.cf_asn" data-model="events">ASN</option>
-                      <option value="events.utm_source" data-model="events">UTM source</option>
-                      <option value="events.utm_campaign" data-model="events">UTM campaign</option>
-                    </optgroup>
-                    <optgroup label="Pageviews">
-                      <option value="pageviews.pathname" data-model="pageviews">Path</option>
-                      <option value="pageviews.host" data-model="pageviews">Host</option>
-                      <option value="pageviews.referrer_domain" data-model="pageviews">Referring domain</option>
-                      <option value="pageviews.referrer" data-model="pageviews">Referrer</option>
-                      <option value="pageviews.browser" data-model="pageviews">Browser</option>
-                      <option value="pageviews.os" data-model="pageviews">OS</option>
-                      <option value="pageviews.device_type" data-model="pageviews">Device</option>
-                      <option value="pageviews.geo_country_code" data-model="pageviews">Country</option>
-                      <option value="pageviews.geo_region" data-model="pageviews">Region</option>
-                      <option value="pageviews.geo_city" data-model="pageviews">City</option>
-                      <option value="pageviews.geo_timezone" data-model="pageviews">Timezone</option>
-                      <option value="pageviews.cf_asn" data-model="pageviews">ASN</option>
-                      <option value="pageviews.utm_source" data-model="pageviews">UTM source</option>
-                      <option value="pageviews.utm_campaign" data-model="pageviews">UTM campaign</option>
-                    </optgroup>
-                    <optgroup label="Sessions">
-                      <option value="sessions.landing_path" data-model="sessions">Landing path</option>
-                      <option value="sessions.browser" data-model="sessions">Browser</option>
-                      <option value="sessions.os" data-model="sessions">OS</option>
-                      <option value="sessions.device_type" data-model="sessions">Device</option>
-                      <option value="sessions.referrer_domain" data-model="sessions">Referring domain</option>
-                      <option value="sessions.referrer" data-model="sessions">Referrer</option>
-                      <option value="sessions.geo_country_code" data-model="sessions">Country</option>
-                      <option value="sessions.geo_region" data-model="sessions">Region</option>
-                      <option value="sessions.geo_city" data-model="sessions">City</option>
-                      <option value="sessions.geo_timezone" data-model="sessions">Timezone</option>
-                      <option value="sessions.cf_asn" data-model="sessions">ASN</option>
-                      <option value="sessions.utm_source" data-model="sessions">UTM source</option>
-                    </optgroup>
-                  </select>
-                </div>
-                <div class="field wide">
-                  <label class="label" for="granularity">Trend grain</label>
-                  <select id="granularity" name="granularity">
-                    <option value="hour">Hour</option>
-                    <option value="day" selected>Day</option>
-                    <option value="week">Week</option>
-                    <option value="month">Month</option>
-                  </select>
-                </div>
+                <input id="dimension" type="hidden" value="events.event_type" />
               </div>
               <input id="semanticFilters" name="semantic_filters" type="hidden" />
               <div class="semantic-filter-block is-hidden" id="semanticFilterBlock">
@@ -1807,6 +1969,8 @@
         dateFrom: document.getElementById("dateFrom"),
         dateTo: document.getElementById("dateTo"),
         datePresets: document.querySelector(".date-presets"),
+        url: document.getElementById("url"),
+        eventName: document.getElementById("eventName"),
         metric: document.getElementById("metric"),
         dimension: document.getElementById("dimension"),
         granularity: document.getElementById("granularity"),
@@ -1875,6 +2039,7 @@
         analyticsPendingPanels: new Set(),
         railCollapsed: false,
         inspectorCollapsed: false,
+        userInspectorCollapsed: null,
       };
 
       const playerControllerHeight = 80;
@@ -1891,7 +2056,6 @@
       const analyticsMetricModels = {
         "events.event_count": "events",
         "events.unique_users": "events",
-        "events.snapshot_events": "events",
         "pageviews.pageviews": "pageviews",
         "sessions.session_count": "sessions",
         "sessions.average_session_seconds": "sessions",
@@ -1902,33 +2066,124 @@
         pageviews: "pageviews.pathname",
         sessions: "sessions.landing_path",
       };
-      const analyticsBreakdownLimit = 10;
-
       const analyticsPanelOrder = [
         "summary",
         "series",
-        "focus_breakdown",
         "top_events",
         "top_pages",
         "domains",
         "referring_domains",
         "referrers",
         "browsers",
+        "operating_systems",
+        "devices",
         "countries",
         "regions",
         "cities",
+        "timezones",
+        "asns",
+        "utm_sources",
+        "utm_campaigns",
       ];
-      const analyticsBuiltInBreakdownPanels = {
-        "events.event_type": "top_events",
-        "pageviews.pathname": "top_pages",
-        "pageviews.host": "domains",
-        "pageviews.referrer_domain": "referring_domains",
-        "pageviews.referrer": "referrers",
-        "events.browser": "browsers",
-        "events.geo_country_code": "countries",
-        "events.geo_region": "regions",
-        "events.geo_city": "cities",
+      const analyticsLeaderboardDimensions = {
+        events: {
+          top_events: "events.event_type",
+          top_pages: "events.pathname",
+          domains: "events.host",
+          referring_domains: "events.referrer_domain",
+          referrers: "events.referrer",
+          browsers: "events.browser",
+          operating_systems: "events.os",
+          devices: "events.device_type",
+          countries: "events.geo_country_code",
+          regions: "events.geo_region",
+          cities: "events.geo_city",
+          timezones: "events.geo_timezone",
+          asns: "events.cf_asn",
+          utm_sources: "events.utm_source",
+          utm_campaigns: "events.utm_campaign",
+        },
+        pageviews: {
+          top_events: "pageviews.event_type",
+          top_pages: "pageviews.pathname",
+          domains: "pageviews.host",
+          referring_domains: "pageviews.referrer_domain",
+          referrers: "pageviews.referrer",
+          browsers: "pageviews.browser",
+          operating_systems: "pageviews.os",
+          devices: "pageviews.device_type",
+          countries: "pageviews.geo_country_code",
+          regions: "pageviews.geo_region",
+          cities: "pageviews.geo_city",
+          timezones: "pageviews.geo_timezone",
+          asns: "pageviews.cf_asn",
+          utm_sources: "pageviews.utm_source",
+          utm_campaigns: "pageviews.utm_campaign",
+        },
+        sessions: {
+          top_pages: "sessions.landing_path",
+          referring_domains: "sessions.referrer_domain",
+          referrers: "sessions.referrer",
+          browsers: "sessions.browser",
+          operating_systems: "sessions.os",
+          devices: "sessions.device_type",
+          countries: "sessions.geo_country_code",
+          regions: "sessions.geo_region",
+          cities: "sessions.geo_city",
+          timezones: "sessions.geo_timezone",
+          asns: "sessions.cf_asn",
+          utm_sources: "sessions.utm_source",
+        },
       };
+      const analyticsDimensionMeta = {
+        "events.event_type": { label: "Event", title: "Events" },
+        "events.pathname": { label: "Page", title: "Pages" },
+        "events.host": { label: "Host", title: "Domains" },
+        "events.referrer_domain": { label: "Referring domain", title: "Referring domains" },
+        "events.referrer": { label: "Referrer", title: "Referrers" },
+        "events.browser": { label: "Browser", title: "Browsers" },
+        "events.os": { label: "OS", title: "Operating systems" },
+        "events.device_type": { label: "Device", title: "Devices" },
+        "events.geo_country_code": { label: "Country", title: "Countries" },
+        "events.geo_region": { label: "Region", title: "Regions" },
+        "events.geo_city": { label: "City", title: "Cities" },
+        "events.geo_timezone": { label: "Timezone", title: "Timezones" },
+        "events.cf_asn": { label: "ASN", title: "ASNs" },
+        "events.utm_source": { label: "UTM source", title: "UTM sources" },
+        "events.utm_campaign": { label: "UTM campaign", title: "UTM campaigns" },
+        "pageviews.event_type": { label: "Event", title: "Events" },
+        "pageviews.pathname": { label: "Page", title: "Pages" },
+        "pageviews.host": { label: "Host", title: "Domains" },
+        "pageviews.referrer_domain": { label: "Referring domain", title: "Referring domains" },
+        "pageviews.referrer": { label: "Referrer", title: "Referrers" },
+        "pageviews.browser": { label: "Browser", title: "Browsers" },
+        "pageviews.os": { label: "OS", title: "Operating systems" },
+        "pageviews.device_type": { label: "Device", title: "Devices" },
+        "pageviews.geo_country_code": { label: "Country", title: "Countries" },
+        "pageviews.geo_region": { label: "Region", title: "Regions" },
+        "pageviews.geo_city": { label: "City", title: "Cities" },
+        "pageviews.geo_timezone": { label: "Timezone", title: "Timezones" },
+        "pageviews.cf_asn": { label: "ASN", title: "ASNs" },
+        "pageviews.utm_source": { label: "UTM source", title: "UTM sources" },
+        "pageviews.utm_campaign": { label: "UTM campaign", title: "UTM campaigns" },
+        "sessions.landing_path": { label: "Landing path", title: "Landing paths" },
+        "sessions.referrer_domain": { label: "Referring domain", title: "Referring domains" },
+        "sessions.referrer": { label: "Referrer", title: "Referrers" },
+        "sessions.browser": { label: "Browser", title: "Browsers" },
+        "sessions.os": { label: "OS", title: "Operating systems" },
+        "sessions.device_type": { label: "Device", title: "Devices" },
+        "sessions.geo_country_code": { label: "Country", title: "Countries" },
+        "sessions.geo_region": { label: "Region", title: "Regions" },
+        "sessions.geo_city": { label: "City", title: "Cities" },
+        "sessions.geo_timezone": { label: "Timezone", title: "Timezones" },
+        "sessions.cf_asn": { label: "ASN", title: "ASNs" },
+        "sessions.utm_source": { label: "UTM source", title: "UTM sources" },
+      };
+      const analyticsBuiltInBreakdownPanels = Object.fromEntries(
+        Object.values(analyticsLeaderboardDimensions).flatMap((panels) =>
+          Object.entries(panels).map(([panel, dimension]) => [dimension, panel]),
+        ),
+      );
 
       const funnelEventOptions = [
         "",
@@ -1941,6 +2196,19 @@
       ];
       const defaultFunnelSteps = ["Viewed Pricing", "Checkout Started", ""];
       const defaultAnalyticsDatePreset = "30d";
+      const datePresetOptions = [
+        { key: "today", label: "Today", shortLabel: "Today" },
+        { key: "24h", label: "Past 24h", shortLabel: "24h" },
+        { key: "72h", label: "Past 72h", shortLabel: "72h" },
+        { key: "7d", label: "Past 7d", shortLabel: "7d" },
+        { key: "14d", label: "Past 14d", shortLabel: "14d" },
+        { key: "30d", label: "Past 30d", shortLabel: "30d" },
+        { key: "quarter", label: "Past quarter", shortLabel: "Quarter" },
+        { key: "year", label: "Past year", shortLabel: "1y" },
+        { key: "2y", label: "Past 2 years", shortLabel: "2y" },
+        { key: "5y", label: "Past 5 years", shortLabel: "5y" },
+        { key: "max", label: "Max", shortLabel: "Max" },
+      ];
       const analyticsPath = "/analytics";
       const replayPath = "/replay";
 
@@ -2020,9 +2288,10 @@
       }
 
       function applyDatePreset(preset) {
-        if (preset === "clear") {
+        if (preset === "max") {
           setDateRange(null, null);
-          setDatePresetState("clear");
+          setGranularityForDatePreset(preset);
+          setDatePresetState("max");
           requestSearchForCurrentMode();
           return;
         }
@@ -2032,10 +2301,22 @@
           from.setHours(0, 0, 0, 0);
         } else if (preset === "24h") {
           from.setDate(from.getDate() - 1);
+        } else if (preset === "72h") {
+          from.setDate(from.getDate() - 3);
         } else if (preset === "7d") {
           from.setDate(from.getDate() - 7);
+        } else if (preset === "14d") {
+          from.setDate(from.getDate() - 14);
         } else if (preset === "30d") {
           from.setDate(from.getDate() - 30);
+        } else if (preset === "quarter") {
+          from.setDate(from.getDate() - 90);
+        } else if (preset === "year") {
+          from.setFullYear(from.getFullYear() - 1);
+        } else if (preset === "2y") {
+          from.setFullYear(from.getFullYear() - 2);
+        } else if (preset === "5y") {
+          from.setFullYear(from.getFullYear() - 5);
         } else {
           return;
         }
@@ -2046,7 +2327,7 @@
       }
 
       function setDatePresetState(preset) {
-        for (const button of els.datePresets.querySelectorAll("[data-date-preset]")) {
+        for (const button of document.querySelectorAll("[data-date-preset]")) {
           const selected = button.dataset.datePreset === preset;
           button.classList.toggle("is-selected", selected);
           button.setAttribute("aria-pressed", selected ? "true" : "false");
@@ -2055,10 +2336,14 @@
 
       function setGranularityForDatePreset(preset) {
         if (state.mode !== "overview") return;
-        if (preset === "24h") {
+        if (preset === "today" || preset === "24h" || preset === "72h") {
           els.granularity.value = "hour";
-        } else if ((preset === "7d" || preset === "30d") && els.granularity.value === "hour") {
+        } else if (preset === "7d" || preset === "14d" || preset === "30d") {
           els.granularity.value = "day";
+        } else if (preset === "quarter" || preset === "year") {
+          els.granularity.value = "week";
+        } else if (preset === "2y" || preset === "5y" || preset === "max") {
+          els.granularity.value = "month";
         }
       }
 
@@ -2079,7 +2364,7 @@
         const from = dateFromInput(els.dateFrom.value);
         const to = dateFromInput(els.dateTo.value);
         if (!from || !to) {
-          setDatePresetState("");
+          setDatePresetState(!from && !to ? "max" : "");
           return;
         }
         const minute = 60 * 1000;
@@ -2091,10 +2376,22 @@
           setDatePresetState("today");
         } else if (Math.abs(elapsed - 24 * 60 * minute) <= tolerance) {
           setDatePresetState("24h");
+        } else if (Math.abs(elapsed - 72 * 60 * minute) <= tolerance) {
+          setDatePresetState("72h");
         } else if (Math.abs(elapsed - 7 * 24 * 60 * minute) <= tolerance) {
           setDatePresetState("7d");
+        } else if (Math.abs(elapsed - 14 * 24 * 60 * minute) <= tolerance) {
+          setDatePresetState("14d");
         } else if (Math.abs(elapsed - 30 * 24 * 60 * minute) <= tolerance) {
           setDatePresetState("30d");
+        } else if (Math.abs(elapsed - 90 * 24 * 60 * minute) <= tolerance) {
+          setDatePresetState("quarter");
+        } else if (Math.abs(elapsed - 365 * 24 * 60 * minute) <= 2 * 24 * 60 * minute) {
+          setDatePresetState("year");
+        } else if (Math.abs(elapsed - 2 * 365 * 24 * 60 * minute) <= 4 * 24 * 60 * minute) {
+          setDatePresetState("2y");
+        } else if (Math.abs(elapsed - 5 * 365 * 24 * 60 * minute) <= 10 * 24 * 60 * minute) {
+          setDatePresetState("5y");
         } else {
           setDatePresetState("");
         }
@@ -2145,12 +2442,14 @@
       }
 
       function initAnalyticsControls() {
-        for (const select of [els.metric, els.dimension, els.granularity]) {
+        for (const select of [els.metric, els.granularity]) {
           select.addEventListener("change", () => {
             if (select === els.metric) syncAnalyticsDimensions();
             if (state.mode === "overview") {
               if (select === els.granularity) {
                 requestAnalyticsSearch({ panels: ["series"] });
+              } else if (select === els.metric) {
+                requestAnalyticsSearch({ panels: analyticsPanelsForCurrentQuery() });
               } else {
                 requestAnalyticsSearch({ panels: analyticsFocusPanels() });
               }
@@ -2163,15 +2462,7 @@
 
       function syncAnalyticsDimensions() {
         const model = analyticsMetricModels[els.metric.value] || "events";
-        const defaultDimension = analyticsDefaultDimensions[model];
-        let selectedStillValid = false;
-        for (const option of els.dimension.options) {
-          const enabled = !option.dataset.model || option.dataset.model === model;
-          option.disabled = !enabled;
-          option.hidden = !enabled;
-          if (enabled && option.value === els.dimension.value) selectedStillValid = true;
-        }
-        if (!selectedStillValid) els.dimension.value = defaultDimension;
+        els.dimension.value = analyticsDefaultDimensions[model] || "events.event_type";
       }
 
       function semanticFilters() {
@@ -2250,8 +2541,7 @@
       }
 
       function semanticFilterLabel(dimension) {
-        const option = Array.from(els.dimension.options).find((candidate) => candidate.value === dimension);
-        return option?.textContent || dimension;
+        return analyticsDimensionMeta[dimension]?.label || dimension;
       }
 
       function updateStepsFromControls() {
@@ -2296,6 +2586,7 @@
         state.section = mode === "overview" ? "analytics" : "replays";
         if (state.section === "replays") state.lastReplayMode = mode;
         syncSectionControls();
+        syncInspectorVisibility();
         renderSemanticFilters();
         for (const [key, button] of [
           ["sessions", els.sessionMode],
@@ -2322,12 +2613,15 @@
       function syncSectionControls() {
         const analyticsSelected = state.mode === "overview";
         state.section = analyticsSelected ? "analytics" : "replays";
+        els.app.classList.toggle("analytics-mode", analyticsSelected);
         els.replaySection.setAttribute("aria-selected", analyticsSelected ? "false" : "true");
         els.analyticsSection.setAttribute("aria-selected", analyticsSelected ? "true" : "false");
         els.resultsPane.classList.toggle("is-hidden", analyticsSelected);
         for (const field of document.querySelectorAll("[data-section]")) {
           field.classList.toggle("is-hidden", field.dataset.section !== state.section);
         }
+        window.requestAnimationFrame(schedulePlayerResize);
+        window.requestAnimationFrame(scheduleChartResize);
       }
 
       function formatTime(value) {
@@ -2608,8 +2902,7 @@
           state.mode = "overview";
           syncSectionControls();
           prepareAnalyticsShell(panels);
-          state.selectedSession = null;
-          state.sessionPayload = null;
+          clearReplayInspectorContext();
           renderResults();
           renderCharts(state.charts);
           renderChartContext();
@@ -2654,8 +2947,7 @@
         const body = await requestJson("/replay/api/sessions", paramsFromForm({ mode: "sessions" }));
         state.sessions = body.sessions || [];
         if (!options.keepSelection) {
-          state.selectedSession = null;
-          state.sessionPayload = null;
+          clearReplayInspectorContext();
         }
         renderResults();
         setStatus(`${state.sessions.length} sessions`, true);
@@ -2672,7 +2964,7 @@
         setStatus("loading");
         const body = await requestJson("/replay/api/events", paramsFromForm({ mode: "events" }));
         state.events = body.events || [];
-        state.selectedEvent = null;
+        clearReplayInspectorContext();
         renderResults();
         setStatus(`${state.events.length} events`, true);
         renderEventContext();
@@ -2682,7 +2974,7 @@
         setStatus("loading");
         const body = await requestJson("/replay/api/funnels", paramsFromForm({ mode: "funnels" }));
         state.funnels = body.sessions || [];
-        state.selectedFunnel = null;
+        clearReplayInspectorContext();
         renderResults();
         setStatus(`${state.funnels.length} funnel sessions`, true);
         renderFunnelContext(body);
@@ -2692,7 +2984,7 @@
         setStatus("loading");
         const body = await requestJson("/replay/api/friction", paramsFromForm({ mode: "friction" }));
         state.friction = body.sessions || [];
-        state.selectedFriction = null;
+        clearReplayInspectorContext();
         renderResults();
         setStatus(`${state.friction.length} flagged sessions`, true);
         renderFrictionContext();
@@ -2702,7 +2994,7 @@
         setStatus("loading");
         const body = await requestJson("/replay/api/person", paramsFromForm({ mode: "person" }));
         state.person = body;
-        state.selectedPersonItem = null;
+        clearReplayInspectorContext();
         renderResults();
         setStatus(`${(body.timeline || []).length} journey items`, true);
         renderPersonContext();
@@ -2820,10 +3112,10 @@
       }
 
       function analyticsFocusPanels() {
-        const panels = ["series", "focus_breakdown"];
+        const panels = ["series"];
         const visiblePanels = analyticsPanelsForCurrentQuery();
         for (const panel of visiblePanels) {
-          if (["summary", "series", "focus_breakdown"].includes(panel)) continue;
+          if (["summary", "series"].includes(panel)) continue;
           if (!state.charts?.breakdowns?.some((breakdown) => breakdown.panel_key === panel)) panels.push(panel);
         }
         return panels;
@@ -2837,18 +3129,19 @@
         }
         state.charts.focus = shell.focus;
         if (panels.includes("series")) state.charts.series = [];
-        if (panels.includes("focus_breakdown")) {
-          state.charts.breakdowns = (state.charts.breakdowns || []).filter(
-            (breakdown) => breakdown.panel_key !== "focus_breakdown",
-          );
-        }
+        const pendingBreakdowns = new Set(panels.filter((panel) => !["summary", "series"].includes(panel)));
+        state.charts.breakdowns = (state.charts.breakdowns || []).filter(
+          (breakdown) => !pendingBreakdowns.has(breakdown.panel_key || breakdownPanelKey(breakdown)),
+        );
       }
 
       function analyticsPanelsForCurrentQuery() {
         const focus = analyticsFocusFromCurrentForm();
-        const focusBuiltinPanel = analyticsBuiltInBreakdownPanels[focus.dimension];
+        const model = analyticsMetricModels[focus.metric] || "events";
+        const supportedPanels = analyticsLeaderboardDimensions[model] || {};
         return analyticsPanelOrder.filter((panel) => {
-          if (panel === focusBuiltinPanel) return false;
+          if (["summary", "series"].includes(panel)) return true;
+          if (!supportedPanels[panel]) return false;
           return true;
         });
       }
@@ -2879,20 +3172,11 @@
         if (panelIndex >= 0) return panelIndex;
         const key = `${breakdown?.model}.${breakdown?.dimension}`;
         const focus = state.charts?.focus || analyticsFocusFromCurrentForm();
+        const model = analyticsMetricModels[focus.metric] || "events";
         const selectedMetric = focus.metric;
         const selectedDimension = focus.dimension;
         if (breakdown?.metric === selectedMetric && key === selectedDimension) return 0;
-        const order = [
-          "events.event_type",
-          "pageviews.pathname",
-          "pageviews.host",
-          "pageviews.referrer_domain",
-          "pageviews.referrer",
-          "events.browser",
-          "events.geo_country_code",
-          "events.geo_region",
-          "events.geo_city",
-        ];
+        const order = Object.values(analyticsLeaderboardDimensions[model] || {});
         const index = order.indexOf(key);
         return index < 0 ? order.length + 1 : index + 1;
       }
@@ -2911,13 +3195,254 @@
 
         const wrap = document.createElement("div");
         wrap.className = "chart-overview";
-        wrap.append(renderMetricGrid(charts?.summary || [], charts?.focus?.metric));
+        wrap.append(renderAnalyticsToolbar());
+        wrap.append(renderMetricGrid(charts?.summary || []));
         wrap.append(renderSeriesPanel(charts));
         wrap.append(renderBreakdownGrid(charts?.breakdowns || []));
         els.player.appendChild(wrap);
       }
 
-      function renderMetricGrid(metrics, selectedMetricRef = "") {
+      function renderAnalyticsToolbar() {
+        const bar = document.createElement("section");
+        bar.className = "analytics-control-bar";
+        bar.setAttribute("aria-label", "Analytics controls");
+
+        const left = document.createElement("div");
+        left.className = "analytics-control-left";
+        left.append(renderAnalyticsFilterMenu(), renderAnalyticsActiveFilters());
+
+        const right = document.createElement("div");
+        right.className = "analytics-control-right";
+        right.append(renderAnalyticsDateMenu());
+        bar.append(left, right);
+        return bar;
+      }
+
+      function renderAnalyticsFilterMenu() {
+        const menu = document.createElement("details");
+        menu.className = "analytics-filter-menu";
+
+        const trigger = document.createElement("summary");
+        trigger.className = "analytics-filter-trigger";
+        trigger.setAttribute("aria-label", "Filters");
+        trigger.innerHTML = `
+          <span class="sr-only">Filters</span>
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 5h18" />
+            <path d="M6 12h12" />
+            <path d="M10 19h4" />
+          </svg>
+        `;
+
+        const popover = document.createElement("div");
+        popover.className = "analytics-filter-popover";
+
+        const metricLabel = document.createElement("label");
+        metricLabel.innerHTML = '<span class="label">Metric</span>';
+        const metricSelect = els.metric.cloneNode(true);
+        metricSelect.removeAttribute("id");
+        metricSelect.removeAttribute("name");
+        metricSelect.value = els.metric.value;
+        metricSelect.addEventListener("change", () => {
+          els.metric.value = metricSelect.value;
+          syncAnalyticsDimensions();
+          requestAnalyticsSearch({ panels: analyticsPanelsForCurrentQuery() });
+        });
+        metricLabel.appendChild(metricSelect);
+
+        const urlLabel = document.createElement("label");
+        urlLabel.innerHTML = '<span class="label">URL contains</span>';
+        const urlInput = document.createElement("input");
+        urlInput.type = "text";
+        urlInput.value = els.url.value;
+        urlInput.placeholder = "/checkout";
+        bindAnalyticsTextFilter(urlInput, els.url);
+        urlLabel.appendChild(urlInput);
+
+        const eventLabel = document.createElement("label");
+        eventLabel.innerHTML = '<span class="label">Event name</span>';
+        const eventInput = document.createElement("input");
+        eventInput.type = "text";
+        eventInput.value = els.eventName.value;
+        eventInput.placeholder = "Product Viewed";
+        bindAnalyticsTextFilter(eventInput, els.eventName);
+        eventLabel.appendChild(eventInput);
+
+        popover.append(metricLabel, urlLabel, eventLabel);
+        menu.append(trigger, popover);
+        return menu;
+      }
+
+      function bindAnalyticsTextFilter(toolbarInput, sourceInput) {
+        const commit = () => {
+          const next = toolbarInput.value.trim();
+          if (sourceInput.value.trim() === next) return;
+          sourceInput.value = next;
+          requestAnalyticsSearch();
+        };
+        toolbarInput.addEventListener("change", commit);
+        toolbarInput.addEventListener("keydown", (event) => {
+          if (event.key !== "Enter") return;
+          event.preventDefault();
+          commit();
+        });
+      }
+
+      function renderAnalyticsDateMenu() {
+        const menu = document.createElement("details");
+        menu.className = "analytics-date-menu";
+
+        const trigger = document.createElement("summary");
+        trigger.className = "analytics-date-trigger";
+        trigger.setAttribute("aria-label", "Date range");
+        const triggerLabel = document.createElement("span");
+        triggerLabel.textContent = analyticsDateRangeText();
+        trigger.appendChild(triggerLabel);
+        trigger.insertAdjacentHTML(
+          "beforeend",
+          '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6" /></svg>',
+        );
+
+        const popover = document.createElement("div");
+        popover.className = "analytics-date-popover";
+
+        const presets = document.createElement("div");
+        presets.className = "analytics-date-presets";
+        const selectedPreset = selectedDatePreset();
+        for (const preset of datePresetOptions) {
+          const button = document.createElement("button");
+          const selected = preset.key === selectedPreset;
+          button.className = "preset-button analytics-date-option";
+          button.type = "button";
+          button.dataset.datePreset = preset.key;
+          button.textContent = preset.label;
+          button.setAttribute("aria-label", preset.label);
+          button.setAttribute("aria-pressed", selected ? "true" : "false");
+          button.classList.toggle("is-selected", selected);
+          button.addEventListener("click", () => {
+            menu.open = false;
+            applyDatePreset(preset.key);
+          });
+          presets.appendChild(button);
+        }
+
+        const custom = document.createElement("div");
+        custom.className = "analytics-custom-range";
+        const fromLabel = document.createElement("label");
+        fromLabel.innerHTML = '<span class="label">From</span>';
+        const fromInput = document.createElement("input");
+        fromInput.type = "datetime-local";
+        fromInput.step = "60";
+        fromInput.value = els.dateFrom.value;
+        fromLabel.appendChild(fromInput);
+
+        const toLabel = document.createElement("label");
+        toLabel.innerHTML = '<span class="label">To</span>';
+        const toInput = document.createElement("input");
+        toInput.type = "datetime-local";
+        toInput.step = "60";
+        toInput.value = els.dateTo.value;
+        toLabel.appendChild(toInput);
+
+        const grainLabel = document.createElement("label");
+        grainLabel.innerHTML = '<span class="label">Date grain</span>';
+        const grain = els.granularity.cloneNode(true);
+        grain.removeAttribute("id");
+        grain.removeAttribute("name");
+        grain.className = "analytics-grain-select";
+        grain.setAttribute("aria-label", "Date grain");
+        grain.value = els.granularity.value;
+        grain.addEventListener("change", () => {
+          els.granularity.value = grain.value;
+          requestAnalyticsSearch({ panels: ["series"] });
+        });
+        grainLabel.appendChild(grain);
+
+        const actions = document.createElement("div");
+        actions.className = "analytics-date-actions";
+        const apply = document.createElement("button");
+        apply.className = "button secondary";
+        apply.type = "button";
+        apply.textContent = "Apply range";
+        apply.addEventListener("click", () => {
+          els.dateFrom.value = fromInput.value;
+          els.dateTo.value = toInput.value;
+          syncDatePresetFromInputs();
+          menu.open = false;
+          requestAnalyticsSearch();
+        });
+        actions.appendChild(apply);
+
+        custom.append(fromLabel, toLabel, grainLabel, actions);
+        popover.append(presets, custom);
+        menu.append(trigger, popover);
+        return menu;
+      }
+
+      function renderAnalyticsActiveFilters() {
+        const wrap = document.createElement("div");
+        wrap.className = "analytics-active-filters";
+        const active = [];
+        if (els.url.value.trim()) {
+          active.push({
+            label: `URL: ${els.url.value.trim()}`,
+            remove: () => {
+              els.url.value = "";
+              requestAnalyticsSearch();
+            },
+          });
+        }
+        if (els.eventName.value.trim()) {
+          active.push({
+            label: `Event: ${els.eventName.value.trim()}`,
+            remove: () => {
+              els.eventName.value = "";
+              requestAnalyticsSearch();
+            },
+          });
+        }
+        for (const item of semanticFilterEntries()) {
+          active.push({
+            label: `${semanticFilterLabel(item.dimension)}: ${item.value}`,
+            remove: () => removeSemanticFilter(item.dimension, item.value),
+          });
+        }
+        for (const item of active) {
+          const pill = document.createElement("span");
+          pill.className = "semantic-filter-pill";
+          const label = document.createElement("span");
+          label.textContent = item.label;
+          const button = document.createElement("button");
+          button.type = "button";
+          button.textContent = "×";
+          button.setAttribute("aria-label", `Remove ${item.label}`);
+          button.addEventListener("click", item.remove);
+          pill.append(label, button);
+          wrap.appendChild(pill);
+        }
+        return wrap;
+      }
+
+      function selectedDatePreset() {
+        return document.querySelector("[data-date-preset].is-selected")?.dataset.datePreset || "";
+      }
+
+      function analyticsDateRangeText() {
+        const preset = datePresetOptions.find((item) => item.key === selectedDatePreset());
+        if (preset) return preset.shortLabel;
+        const from = dateFromInput(els.dateFrom.value);
+        const to = dateFromInput(els.dateTo.value);
+        if (!from && !to) return "Max";
+        if (from && to) return `${formatShortDate(from)} - ${formatShortDate(to)}`;
+        if (from) return `From ${formatShortDate(from)}`;
+        return `Until ${formatShortDate(to)}`;
+      }
+
+      function formatShortDate(date) {
+        return new Intl.DateTimeFormat(undefined, { month: "numeric", day: "numeric" }).format(date);
+      }
+
+      function renderMetricGrid(metrics) {
         const grid = document.createElement("section");
         grid.className = "metric-grid";
         grid.setAttribute("aria-label", "Analytics metrics");
@@ -2925,7 +3450,7 @@
         grid.classList.toggle("is-pending", pending);
         if (!metrics.length) {
           if (pending) {
-            for (let index = 0; index < 6; index += 1) {
+            for (let index = 0; index < 5; index += 1) {
               grid.appendChild(renderMetricSkeletonCard(index));
             }
           } else {
@@ -2940,8 +3465,20 @@
           const card = document.createElement("div");
           card.className = "metric-card";
           card.dataset.metric = metric.semantic_ref;
-          card.classList.toggle("is-selected", metric.semantic_ref === selectedMetricRef);
-          if (metric.semantic_ref === selectedMetricRef) card.setAttribute("aria-current", "true");
+          const selectable = Boolean(analyticsMetricModels[metric.semantic_ref]);
+          card.classList.toggle("is-selectable", selectable);
+          card.classList.toggle("is-selected", metric.semantic_ref === chartsFocusMetric());
+          if (selectable) {
+            card.setAttribute("role", "button");
+            card.setAttribute("tabindex", "0");
+            if (metric.semantic_ref === chartsFocusMetric()) card.setAttribute("aria-current", "true");
+            card.addEventListener("click", () => selectAnalyticsMetric(metric.semantic_ref));
+            card.addEventListener("keydown", (event) => {
+              if (event.key !== "Enter" && event.key !== " ") return;
+              event.preventDefault();
+              selectAnalyticsMetric(metric.semantic_ref);
+            });
+          }
           const label = document.createElement("span");
           label.textContent = metric.label;
           const value = document.createElement("strong");
@@ -2952,6 +3489,10 @@
           grid.appendChild(card);
         }
         return grid;
+      }
+
+      function chartsFocusMetric() {
+        return state.charts?.focus?.metric || analyticsFocusFromCurrentForm().metric;
       }
 
       function renderMetricSkeletonCard(index) {
@@ -3082,26 +3623,15 @@
 
       function breakdownPanelKey(breakdown) {
         const key = `${breakdown?.model}.${breakdown?.dimension}`;
-        const focus = state.charts?.focus || analyticsFocusFromCurrentForm();
-        if (breakdown?.metric === focus.metric && key === focus.dimension) return "focus_breakdown";
         return analyticsBuiltInBreakdownPanels[key] || key;
       }
 
       function loadingBreakdownTitle(panel) {
         const focus = state.charts?.focus || analyticsFocusFromCurrentForm();
-        const titles = {
-          focus_breakdown: `${analyticsMetricLabel(focus.metric)} by ${analyticsDimensionLabel(focus.dimension)}`,
-          top_events: "Events by Event",
-          top_pages: "Pageviews by Page",
-          domains: "Pageviews by Domain",
-          referring_domains: "Pageviews by Referring domain",
-          referrers: "Pageviews by Referrer",
-          browsers: "Events by Browser",
-          countries: "Events by Country",
-          regions: "Events by Region",
-          cities: "Events by City",
-        };
-        return titles[panel] || "Breakdown";
+        const model = analyticsMetricModels[focus.metric] || "events";
+        const dimension = analyticsLeaderboardDimensions[model]?.[panel];
+        if (!dimension) return "Panel";
+        return analyticsDimensionTitle(dimension);
       }
 
       function renderBreakdownRow(row, breakdown) {
@@ -3273,16 +3803,20 @@
       }
 
       function analyticsFocusFromCurrentForm() {
+        const metric = analyticsMetricModels[els.metric.value] ? els.metric.value : "events.event_count";
         return {
-          metric: els.metric.value || "events.event_count",
+          metric,
           dimension: els.dimension.value || "events.event_type",
           granularity: els.granularity.value || "day",
         };
       }
 
       function analyticsFocusFromParams(params) {
+        const metric = analyticsMetricModels[params.get("metric")]
+          ? params.get("metric")
+          : els.metric.value || "events.event_count";
         return {
-          metric: params.get("metric") || els.metric.value || "events.event_count",
+          metric,
           dimension: params.get("dimension") || els.dimension.value || "events.event_type",
           granularity: params.get("granularity") || els.granularity.value || "day",
         };
@@ -3299,27 +3833,11 @@
       }
 
       function analyticsDimensionLabel(dimensionRef) {
-        return selectedOptionLabel(els.dimension, dimensionRef);
+        return analyticsDimensionMeta[dimensionRef]?.label || dimensionRef;
       }
 
       function analyticsDimensionTitle(dimensionRef) {
-        const titles = {
-          "events.event_type": "Events",
-          "events.browser": "Browsers",
-          "events.geo_country_code": "Countries",
-          "events.geo_region": "Regions",
-          "events.geo_city": "Cities",
-          "pageviews.pathname": "Pages",
-          "pageviews.host": "Domains",
-          "pageviews.referrer_domain": "Referring domains",
-          "pageviews.referrer": "Referrers",
-          "sessions.landing_path": "Landing paths",
-          "sessions.browser": "Session browsers",
-          "sessions.geo_country_code": "Session countries",
-          "sessions.geo_region": "Session regions",
-          "sessions.geo_city": "Session cities",
-        };
-        return titles[dimensionRef] || analyticsDimensionLabel(dimensionRef);
+        return analyticsDimensionMeta[dimensionRef]?.title || analyticsDimensionLabel(dimensionRef);
       }
 
       function semanticFilterEntries() {
@@ -3342,7 +3860,6 @@
         const filters = semanticFilterSummary();
         const pieces = [
           analyticsMetricLabel(focus.metric),
-          `Breakdown: ${analyticsDimensionLabel(focus.dimension)}`,
           `${grainLabel(focus.granularity)} trend`,
         ];
         if (filters !== "No filters") pieces.push(filters);
@@ -3362,18 +3879,11 @@
         els.detailEvents.textContent = session ? String(session.event_count) : "-";
         els.detailChunks.textContent = session ? String(session.chunk_count) : "-";
         els.detailUrl.textContent = session?.first_url || "-";
+        syncInspectorVisibility();
       }
 
       function renderAnalyticsFacts(charts) {
-        const focus = charts?.focus || analyticsFocusFromCurrentForm();
-        els.inspectorTitle.textContent = "Analytics inspector";
-        setFactLabels("Metric", "Breakdown", "Trend", "Rows", "Engine", "State");
-        els.detailDistinct.textContent = analyticsMetricLabel(focus.metric);
-        els.detailSecondary.textContent = analyticsDimensionLabel(focus.dimension);
-        els.detailDuration.textContent = grainLabel(focus.granularity);
-        els.detailEvents.textContent = String(analyticsBreakdownLimit);
-        els.detailChunks.textContent = "Sidemantic";
-        els.detailUrl.textContent = state.analyticsLoading ? "Updating" : "Ready";
+        syncInspectorVisibility();
       }
 
       function setFactLabels(user, secondary, duration, events, chunks, url) {
@@ -3760,6 +4270,37 @@
         window.requestAnimationFrame(scheduleChartResize);
       }
 
+      function replayHasInspectorContext() {
+        return Boolean(
+          state.selectedSession ||
+            state.selectedEvent ||
+            state.selectedFunnel ||
+            state.selectedFriction ||
+            state.selectedPersonItem ||
+            state.sessionPayload,
+        );
+      }
+
+      function clearReplayInspectorContext() {
+        state.selectedSession = null;
+        state.selectedEvent = null;
+        state.selectedFunnel = null;
+        state.selectedFriction = null;
+        state.selectedPersonItem = null;
+        state.sessionPayload = null;
+        syncInspectorVisibility();
+      }
+
+      function syncInspectorVisibility() {
+        const unavailable = state.section === "analytics" || !replayHasInspectorContext();
+        els.app.classList.toggle("inspector-unavailable", unavailable);
+        if (unavailable) {
+          setInspectorCollapsed(true);
+          return;
+        }
+        setInspectorCollapsed(state.userInspectorCollapsed === true);
+      }
+
       function setDebugPayload() {
         els.debugPayload.textContent = JSON.stringify(
           {
@@ -3823,9 +4364,14 @@
       els.personMode.addEventListener("click", () => switchMode("person"));
       els.reload.addEventListener("click", requestSearchForCurrentMode);
       els.toggleRail.addEventListener("click", () => setRailCollapsed(!state.railCollapsed));
-      els.toggleInspector.addEventListener("click", () =>
-        setInspectorCollapsed(!state.inspectorCollapsed),
-      );
+      els.toggleInspector.addEventListener("click", () => {
+        if (state.section === "analytics" || !replayHasInspectorContext()) {
+          setInspectorCollapsed(true);
+          return;
+        }
+        state.userInspectorCollapsed = !state.inspectorCollapsed;
+        setInspectorCollapsed(state.userInspectorCollapsed);
+      });
       els.datePresets.addEventListener("click", (event) => {
         const button = event.target.closest("[data-date-preset]");
         if (!button) return;
@@ -3851,12 +4397,7 @@
         state.funnels = [];
         state.friction = [];
         state.person = null;
-        state.selectedSession = null;
-        state.selectedEvent = null;
-        state.selectedFunnel = null;
-        state.selectedFriction = null;
-        state.selectedPersonItem = null;
-        state.sessionPayload = null;
+        clearReplayInspectorContext();
         if (wasAnalytics) {
           ensureDefaultAnalyticsDateRange();
           requestAnalyticsSearch();
@@ -3877,6 +4418,13 @@
           location.pathname.replace(/\/$/, "") === analyticsPath ||
           params.get("section") === "analytics";
         const bootingReplay = location.pathname.replace(/\/$/, "") === replayPath;
+        const metricParam = params.get("metric");
+        if (bootingAnalytics && metricParam && !analyticsMetricModels[metricParam]) {
+          setMode("overview");
+          setStatus("error");
+          showMessage("error", "Analytics unavailable", `Unsupported analytics metric: ${metricParam}`);
+          return;
+        }
         for (const [key, value] of params.entries()) {
           if (key === "at_ms" || key === "mode" || key === "section") continue;
           setField(key, value);

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -850,7 +850,6 @@
         border-right: 1px solid var(--line);
         background: transparent;
         color: inherit;
-        cursor: pointer;
         font: inherit;
         padding: 9px 12px;
         text-align: left;
@@ -865,7 +864,6 @@
         border-right: 0;
       }
 
-      .metric-card:hover,
       .metric-card.is-selected {
         background: var(--surface-soft);
       }
@@ -1906,6 +1904,9 @@
       const analyticsBreakdownLimit = 10;
 
       const analyticsPanelOrder = [
+        "summary",
+        "series",
+        "focus_breakdown",
         "top_events",
         "top_pages",
         "domains",
@@ -1915,9 +1916,6 @@
         "countries",
         "regions",
         "cities",
-        "summary",
-        "series",
-        "focus_breakdown",
       ];
       const analyticsBuiltInBreakdownPanels = {
         "events.event_type": "top_events",
@@ -2149,7 +2147,13 @@
         for (const select of [els.metric, els.dimension, els.granularity]) {
           select.addEventListener("change", () => {
             if (select === els.metric) syncAnalyticsDimensions();
-            if (state.mode === "overview") requestAnalyticsSearch();
+            if (state.mode === "overview") {
+              if (select === els.granularity) {
+                requestAnalyticsSearch({ panels: ["series"] });
+              } else {
+                requestAnalyticsSearch({ panels: analyticsFocusPanels() });
+              }
+            }
           });
         }
         syncAnalyticsDimensions();
@@ -2568,13 +2572,13 @@
         }
       }
 
-      function requestAnalyticsSearch() {
+      function requestAnalyticsSearch(options = {}) {
         if (state.mode !== "overview") {
           runSearch();
           return;
         }
         replaceAnalyticsUrlFromForm();
-        runSearch();
+        runSearch(options);
       }
 
       async function requestJson(path, params, options = {}) {
@@ -2591,17 +2595,18 @@
         setAnalyticsLoading(false);
       }
 
-      async function loadCharts() {
+      async function loadCharts(options = {}) {
         const requestId = ++state.analyticsRequestId;
         const params = paramsFromForm({ mode: "overview" });
-        const panels = analyticsPanelsForCurrentQuery();
+        const availablePanels = analyticsPanelsForCurrentQuery();
+        const panels = analyticsPanelsForRequest(options.panels, availablePanels);
         state.analyticsPendingPanels = new Set(panels);
         clearStatus();
         setAnalyticsLoading(true);
         try {
           state.mode = "overview";
           syncSectionControls();
-          state.charts = analyticsShellFromForm();
+          prepareAnalyticsShell(panels);
           state.selectedSession = null;
           state.sessionPayload = null;
           renderResults();
@@ -2808,13 +2813,42 @@
         };
       }
 
+      function analyticsPanelsForRequest(requestedPanels, availablePanels = analyticsPanelsForCurrentQuery()) {
+        if (!requestedPanels?.length || !state.charts) return availablePanels;
+        return [...new Set(requestedPanels)].filter((panel) => availablePanels.includes(panel));
+      }
+
+      function analyticsFocusPanels() {
+        const panels = ["series", "focus_breakdown"];
+        const visiblePanels = analyticsPanelsForCurrentQuery();
+        for (const panel of visiblePanels) {
+          if (["summary", "series", "focus_breakdown"].includes(panel)) continue;
+          if (!state.charts?.breakdowns?.some((breakdown) => breakdown.panel_key === panel)) panels.push(panel);
+        }
+        return panels;
+      }
+
+      function prepareAnalyticsShell(panels) {
+        const shell = analyticsShellFromForm();
+        if (!state.charts || panels.includes("summary")) {
+          state.charts = shell;
+          return;
+        }
+        state.charts.focus = shell.focus;
+        if (panels.includes("series")) state.charts.series = [];
+        if (panels.includes("focus_breakdown")) {
+          state.charts.breakdowns = (state.charts.breakdowns || []).filter(
+            (breakdown) => breakdown.panel_key !== "focus_breakdown",
+          );
+        }
+      }
+
       function analyticsPanelsForCurrentQuery() {
         const focus = analyticsFocusFromCurrentForm();
+        const focusBuiltinPanel = analyticsBuiltInBreakdownPanels[focus.dimension];
         return analyticsPanelOrder.filter((panel) => {
-          if (panel !== "focus_breakdown") return true;
-          if (analyticsBuiltInBreakdownPanels[focus.dimension]) return false;
-          const dimensionName = focus.dimension.split(".").at(-1);
-          return !["geo_country_code", "geo_region", "geo_city"].includes(dimensionName);
+          if (panel === focusBuiltinPanel) return false;
+          return true;
         });
       }
 
@@ -2902,12 +2936,11 @@
           return grid;
         }
         for (const metric of metrics) {
-          const card = document.createElement("button");
-          card.type = "button";
+          const card = document.createElement("div");
           card.className = "metric-card";
           card.dataset.metric = metric.semantic_ref;
           card.classList.toggle("is-selected", metric.semantic_ref === selectedMetricRef);
-          card.addEventListener("click", () => selectAnalyticsMetric(metric.semantic_ref));
+          if (metric.semantic_ref === selectedMetricRef) card.setAttribute("aria-current", "true");
           const label = document.createElement("span");
           label.textContent = metric.label;
           const value = document.createElement("strong");
@@ -2936,7 +2969,7 @@
         if (!analyticsMetricModels[metricRef]) return;
         els.metric.value = metricRef;
         syncAnalyticsDimensions();
-        if (state.mode === "overview") requestAnalyticsSearch();
+        if (state.mode === "overview") requestAnalyticsSearch({ panels: analyticsFocusPanels() });
       }
 
       function renderSeriesPanel(charts) {
@@ -2970,10 +3003,11 @@
         grid.className = "breakdown-grid";
         grid.setAttribute("aria-label", "Metric breakdowns");
         const rendered = new Set();
+        const visiblePanels = new Set(analyticsPanelsForCurrentQuery());
         const breakdownsByPanel = new Map(
           breakdowns.map((breakdown) => [breakdown.panel_key || breakdownPanelKey(breakdown), breakdown]),
         );
-        for (const panel of analyticsPanelsForCurrentQuery().filter((item) => !["summary", "series"].includes(item))) {
+        for (const panel of [...visiblePanels].filter((item) => !["summary", "series"].includes(item))) {
           const breakdown = breakdownsByPanel.get(panel);
           if (breakdown) {
             rendered.add(breakdown);
@@ -2983,7 +3017,8 @@
           }
         }
         for (const breakdown of breakdowns) {
-          if (!rendered.has(breakdown)) grid.appendChild(renderBreakdownPanel(breakdown));
+          const panel = breakdown.panel_key || breakdownPanelKey(breakdown);
+          if (!rendered.has(breakdown) && visiblePanels.has(panel)) grid.appendChild(renderBreakdownPanel(breakdown));
         }
         return grid;
       }
@@ -3054,16 +3089,16 @@
       function loadingBreakdownTitle(panel) {
         const focus = state.charts?.focus || analyticsFocusFromCurrentForm();
         const titles = {
-          focus_breakdown: analyticsDimensionTitle(focus.dimension),
-          top_events: "Top events",
-          top_pages: "Top pages",
-          domains: "Domains",
-          referring_domains: "Referring domains",
-          referrers: "Referrers",
-          browsers: "Browsers",
-          countries: "Countries",
-          regions: "Regions",
-          cities: "Cities",
+          focus_breakdown: `${analyticsMetricLabel(focus.metric)} by ${analyticsDimensionLabel(focus.dimension)}`,
+          top_events: "Events by Event",
+          top_pages: "Pageviews by Page",
+          domains: "Pageviews by Domain",
+          referring_domains: "Pageviews by Referring domain",
+          referrers: "Pageviews by Referrer",
+          browsers: "Events by Browser",
+          countries: "Events by Country",
+          regions: "Events by Region",
+          cities: "Events by City",
         };
         return titles[panel] || "Breakdown";
       }
@@ -3210,19 +3245,14 @@
 
       function seriesConfig(charts = null) {
         const focusMetric = charts?.focus?.metric || "";
-        const config = [
+        return [
           {
             key: "focused_value",
             ref: focusMetric,
             label: charts?.focus?.metric_label || "Selected",
             color: "#087a55",
           },
-          { key: "event_count", ref: "events.event_count", label: "Events", color: "#5c6670" },
-          { key: "pageviews", ref: "pageviews.pageviews", label: "Pageviews", color: "#2d5f9a" },
-          { key: "session_count", ref: "sessions.session_count", label: "Sessions", color: "#9a6b16" },
-          { key: "recordings", ref: "events.snapshot_events", label: "Recordings", color: "#9d332b" },
         ];
-        return config.filter((item, index) => index === 0 || item.ref !== focusMetric);
       }
 
       function grainLabel(granularity) {
@@ -3740,9 +3770,9 @@
         );
       }
 
-      async function runSearch() {
+      async function runSearch(options = {}) {
         try {
-          if (state.mode === "overview") await loadCharts();
+          if (state.mode === "overview") await loadCharts(options);
           else if (state.mode === "sessions") await loadSessions();
           else if (state.mode === "events") await loadEvents();
           else if (state.mode === "funnels") await loadFunnels();

--- a/src/app_ui.html
+++ b/src/app_ui.html
@@ -333,13 +333,16 @@
         gap: 10px;
       }
 
+      .semantic-filter-block {
+        display: grid;
+        gap: 6px;
+      }
+
       .semantic-filter-strip {
         display: flex;
         align-items: center;
         flex-wrap: wrap;
         gap: 6px;
-        border-top: 1px solid var(--line);
-        padding-top: 8px;
       }
 
       .semantic-filter-pill {
@@ -1488,12 +1491,15 @@
                 </div>
               </div>
               <input id="semanticFilters" name="semantic_filters" type="hidden" />
-              <div
-                class="semantic-filter-strip is-hidden"
-                id="semanticFilterStrip"
-                data-testid="analytics-filter-pills"
-                aria-label="Active analytics filters"
-              ></div>
+              <div class="semantic-filter-block is-hidden" id="semanticFilterBlock">
+                <span class="label">Active filters</span>
+                <div
+                  class="semantic-filter-strip"
+                  id="semanticFilterStrip"
+                  data-testid="analytics-filter-pills"
+                  aria-label="Active analytics filters"
+                ></div>
+              </div>
             </div>
             <div class="field" data-section="replays">
               <label class="label" for="minDuration">Min duration</label>
@@ -1755,6 +1761,7 @@
         dimension: document.getElementById("dimension"),
         granularity: document.getElementById("granularity"),
         semanticFilters: document.getElementById("semanticFilters"),
+        semanticFilterBlock: document.getElementById("semanticFilterBlock"),
         semanticFilterStrip: document.getElementById("semanticFilterStrip"),
         submitButton: document.getElementById("submitButton"),
         clear: document.getElementById("clear"),
@@ -2112,7 +2119,7 @@
         const entries = Object.entries(filters).flatMap(([dimension, values]) =>
           (values || []).map((value) => ({ dimension, value: normalizeFilterValue(value) })).filter((item) => item.value),
         );
-        els.semanticFilterStrip.classList.toggle("is-hidden", !entries.length);
+        els.semanticFilterBlock.classList.toggle("is-hidden", !entries.length);
         for (const item of entries) {
           const pill = document.createElement("span");
           pill.className = "semantic-filter-pill";

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use url::Url;
 
 use crate::feature_flags::FeatureFlagStore;
+use crate::product_analytics::ProductAnalyticsConfig;
 use crate::replay::{ReplayConfig, ReplayConfigError};
 
 #[derive(Debug, Clone)]
@@ -22,6 +23,7 @@ pub struct Config {
     pub posthog_project_api_key: Option<String>,
     pub session_recording_endpoint: Option<String>,
     pub replay: Option<ReplayConfig>,
+    pub analytics: Option<ProductAnalyticsConfig>,
     pub posthog_signing_secret: Option<String>,
     pub person_debug_token: Option<String>,
     pub feature_flags: FeatureFlagStore,
@@ -136,6 +138,7 @@ impl Config {
             .ok()
             .map(|v| v.to_string());
         let replay = replay_config_from_worker_env(env)?;
+        let analytics = analytics_config_from_worker_env(env)?;
         let posthog_signing_secret = env
             .secret("POSTHOG_SIGNING_SECRET")
             .ok()
@@ -174,6 +177,7 @@ impl Config {
             posthog_project_api_key,
             session_recording_endpoint,
             replay,
+            analytics,
             posthog_signing_secret,
             person_debug_token,
             feature_flags,
@@ -269,6 +273,7 @@ impl Config {
         let posthog_project_api_key = env::var("POSTHOG_API_KEY").ok();
         let session_recording_endpoint = env::var("POSTHOG_SESSION_RECORDING_ENDPOINT").ok();
         let replay = replay_config_from_env()?;
+        let analytics = analytics_config_from_env()?;
         let posthog_signing_secret = env::var("POSTHOG_SIGNING_SECRET").ok();
         let person_debug_token = env::var("PERSON_DEBUG_TOKEN").ok();
         let feature_flags = match env::var("HOGFLARE_FEATURE_FLAGS") {
@@ -294,6 +299,7 @@ impl Config {
             posthog_project_api_key,
             session_recording_endpoint,
             replay,
+            analytics,
             posthog_signing_secret,
             person_debug_token,
             feature_flags,
@@ -354,6 +360,50 @@ fn replay_config_from_worker_env(env: &worker::Env) -> Result<Option<ReplayConfi
     .map_err(ConfigError::from)
 }
 
+#[cfg(target_arch = "wasm32")]
+fn analytics_config_from_worker_env(
+    env: &worker::Env,
+) -> Result<Option<ProductAnalyticsConfig>, ConfigError> {
+    let account_id = worker_var_any(
+        env,
+        &[
+            "HOGFLARE_ANALYTICS_ACCOUNT_ID",
+            "HOGFLARE_REPLAY_ACCOUNT_ID",
+        ],
+    );
+    let bucket_name = worker_var_any(
+        env,
+        &["HOGFLARE_ANALYTICS_BUCKET", "HOGFLARE_REPLAY_BUCKET"],
+    );
+    let auth_token = worker_secret_or_var_any(
+        env,
+        &[
+            "HOGFLARE_ANALYTICS_R2_SQL_TOKEN",
+            "HOGFLARE_REPLAY_R2_SQL_TOKEN",
+        ],
+    );
+
+    let configured = account_id.is_some() || bucket_name.is_some() || auth_token.is_some();
+    if !configured {
+        return Ok(None);
+    }
+
+    let events_table = worker_var_any(
+        env,
+        &[
+            "HOGFLARE_ANALYTICS_EVENTS_TABLE",
+            "HOGFLARE_REPLAY_EVENTS_TABLE",
+        ],
+    );
+
+    Ok(Some(ProductAnalyticsConfig::new(
+        account_id.ok_or(ConfigError::MissingVar("HOGFLARE_ANALYTICS_ACCOUNT_ID"))?,
+        bucket_name.ok_or(ConfigError::MissingVar("HOGFLARE_ANALYTICS_BUCKET"))?,
+        auth_token.ok_or(ConfigError::MissingVar("HOGFLARE_ANALYTICS_R2_SQL_TOKEN"))?,
+        events_table,
+    )))
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 fn replay_config_from_env() -> Result<Option<ReplayConfig>, ConfigError> {
     let account_id = env::var("HOGFLARE_REPLAY_ACCOUNT_ID").ok();
@@ -384,6 +434,36 @@ fn replay_config_from_env() -> Result<Option<ReplayConfig>, ConfigError> {
     .map_err(ConfigError::from)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+fn analytics_config_from_env() -> Result<Option<ProductAnalyticsConfig>, ConfigError> {
+    let account_id = env_any(&[
+        "HOGFLARE_ANALYTICS_ACCOUNT_ID",
+        "HOGFLARE_REPLAY_ACCOUNT_ID",
+    ]);
+    let bucket_name = env_any(&["HOGFLARE_ANALYTICS_BUCKET", "HOGFLARE_REPLAY_BUCKET"]);
+    let auth_token = env_any(&[
+        "HOGFLARE_ANALYTICS_R2_SQL_TOKEN",
+        "HOGFLARE_REPLAY_R2_SQL_TOKEN",
+    ]);
+
+    let configured = account_id.is_some() || bucket_name.is_some() || auth_token.is_some();
+    if !configured {
+        return Ok(None);
+    }
+
+    let events_table = env_any(&[
+        "HOGFLARE_ANALYTICS_EVENTS_TABLE",
+        "HOGFLARE_REPLAY_EVENTS_TABLE",
+    ]);
+
+    Ok(Some(ProductAnalyticsConfig::new(
+        account_id.ok_or(ConfigError::MissingVar("HOGFLARE_ANALYTICS_ACCOUNT_ID"))?,
+        bucket_name.ok_or(ConfigError::MissingVar("HOGFLARE_ANALYTICS_BUCKET"))?,
+        auth_token.ok_or(ConfigError::MissingVar("HOGFLARE_ANALYTICS_R2_SQL_TOKEN"))?,
+        events_table,
+    )))
+}
+
 fn parse_replay_query_limit(value: Option<String>) -> Result<Option<usize>, ConfigError> {
     value
         .map(|value| {
@@ -411,4 +491,26 @@ fn parse_optional_url(
             })
         })
         .transpose()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn env_any(names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| env::var(name).ok())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn worker_var_any(env: &worker::Env, names: &[&str]) -> Option<String> {
+    names
+        .iter()
+        .find_map(|name| env.var(name).ok().map(|value| value.to_string()))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn worker_secret_or_var_any(env: &worker::Env, names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| {
+        env.secret(name)
+            .ok()
+            .map(|secret| secret.to_string())
+            .or_else(|| env.var(name).ok().map(|value| value.to_string()))
+    })
 }

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -910,6 +910,7 @@ mod tests {
             pipeline: Arc::new(pipeline),
             persons_pipeline: None,
             replay: None,
+            analytics: None,
             posthog_team_id: None,
             decide_api_token: None,
             session_recording_endpoint: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,9 @@ pub mod importer;
 pub mod models;
 pub mod persons;
 pub mod pipeline;
+pub mod product_analytics;
 pub mod replay;
+pub mod ui;
 
 use std::{collections::HashMap, sync::Arc};
 
@@ -34,6 +36,7 @@ use persons::{
     NoopPersonStore, PersonAlias, PersonError, PersonStore, PersonUpdate,
 };
 use pipeline::{PersonPipelineRecord, PipelineClient, PipelineError, PipelineEvent};
+use product_analytics::{ProductAnalyticsClient, ProductAnalyticsError, ProductAnalyticsQuery};
 use replay::{
     ReplayClient, ReplayError, ReplayEventsQuery, ReplayFrictionQuery, ReplayFunnelQuery,
     ReplayPersonQuery, ReplaySessionEventsQuery, ReplaySessionsQuery,
@@ -63,6 +66,7 @@ pub(crate) struct AppState {
     pub(crate) pipeline: Arc<PipelineClient>,
     pub(crate) persons_pipeline: Option<Arc<PipelineClient>>,
     pub(crate) replay: Option<Arc<ReplayClient>>,
+    pub(crate) analytics: Option<Arc<ProductAnalyticsClient>>,
     pub(crate) posthog_team_id: Option<i64>,
     pub(crate) decide_api_token: Option<String>,
     pub(crate) session_recording_endpoint: Option<String>,
@@ -180,6 +184,11 @@ pub async fn run_with_config(config: Config) -> Result<(), RunError> {
         .map(ReplayClient::new)
         .transpose()?
         .map(Arc::new);
+    let analytics = config
+        .analytics
+        .clone()
+        .map(ProductAnalyticsClient::new)
+        .map(Arc::new);
 
     info!(
         endpoint = %config.pipeline_endpoint,
@@ -199,19 +208,23 @@ pub async fn run_with_config(config: Config) -> Result<(), RunError> {
     let listener = TcpListener::bind(config.address).await?;
     info!(address = %config.address, "listening for requests");
 
-    serve_with_person_pipeline_and_replay(
+    serve_with_state(
         listener,
-        Arc::new(pipeline),
-        persons_pipeline,
-        replay,
-        config.posthog_team_id,
-        Arc::new(NoopGroupStore),
-        GroupTypeMap::new(config.posthog_group_types.clone()),
-        config.posthog_project_api_key.clone(),
-        config.session_recording_endpoint.clone(),
-        config.posthog_signing_secret.clone(),
-        config.person_debug_token.clone(),
-        Arc::new(config.feature_flags),
+        build_state(
+            Arc::new(pipeline),
+            persons_pipeline,
+            replay,
+            analytics,
+            config.posthog_team_id,
+            Arc::new(NoopGroupStore),
+            GroupTypeMap::new(config.posthog_group_types.clone()),
+            config.posthog_project_api_key.clone(),
+            config.session_recording_endpoint.clone(),
+            config.posthog_signing_secret.clone(),
+            config.person_debug_token.clone(),
+            Arc::new(config.feature_flags),
+            Arc::new(persons::MemoryPersonStore::new(config.posthog_team_id)),
+        ),
     )
     .await
 }
@@ -286,11 +299,17 @@ pub async fn fetch(
         },
         None => None,
     };
+    let analytics = config
+        .analytics
+        .clone()
+        .map(ProductAnalyticsClient::new)
+        .map(Arc::new);
 
-    let mut router = build_router_with_person_pipeline_and_replay(
+    let mut router = router(build_state(
         Arc::new(pipeline),
         persons_pipeline,
         replay,
+        analytics,
         config.posthog_team_id,
         group_store,
         group_type_map,
@@ -300,7 +319,7 @@ pub async fn fetch(
         config.person_debug_token.clone(),
         feature_flags,
         person_store,
-    );
+    ));
 
     Ok(router.call(req).await?)
 }
@@ -394,6 +413,7 @@ pub fn build_router_with_person_pipeline_and_replay(
         pipeline,
         persons_pipeline,
         replay,
+        None,
         posthog_team_id,
         group_store,
         group_type_map,
@@ -412,6 +432,7 @@ pub async fn serve(listener: TcpListener, pipeline: Arc<PipelineClient>) -> Resu
         listener,
         build_state(
             pipeline,
+            None,
             None,
             None,
             None,
@@ -507,6 +528,7 @@ pub async fn serve_with_person_pipeline_and_replay(
         pipeline,
         persons_pipeline,
         replay,
+        None,
         posthog_team_id,
         group_store,
         group_type_map,
@@ -522,6 +544,7 @@ pub async fn serve_with_person_pipeline_and_replay(
 
 fn router(state: AppState) -> Router {
     let router = Router::new()
+        .route("/", get(app_ui))
         .route("/capture", post(capture))
         .route("/e", post(browser_capture))
         .route("/e/", post(browser_capture))
@@ -538,8 +561,11 @@ fn router(state: AppState) -> Router {
         .route("/array/:token/config.js", get(array_config_js))
         .route("/s", post(session_recording))
         .route("/s/", post(session_recording))
-        .route("/replay", get(replay_ui))
-        .route("/replay/", get(replay_ui))
+        .route("/analytics", get(app_ui))
+        .route("/analytics/", get(app_ui))
+        .route("/analytics/api/charts", get(product_analytics))
+        .route("/replay", get(app_ui))
+        .route("/replay/", get(app_ui))
         .route("/replay/api/sessions", get(replay_sessions))
         .route("/replay/api/events", get(replay_events))
         .route("/replay/api/funnels", get(replay_funnels))
@@ -567,6 +593,7 @@ fn build_state(
     pipeline: Arc<PipelineClient>,
     persons_pipeline: Option<Arc<PipelineClient>>,
     replay: Option<Arc<ReplayClient>>,
+    analytics: Option<Arc<ProductAnalyticsClient>>,
     posthog_team_id: Option<i64>,
     group_store: Arc<dyn GroupStore>,
     group_type_map: GroupTypeMap,
@@ -581,6 +608,7 @@ fn build_state(
         pipeline,
         persons_pipeline,
         replay,
+        analytics,
         posthog_team_id,
         group_store,
         group_type_map,
@@ -1727,8 +1755,8 @@ async fn health() -> impl IntoResponse {
 }
 
 #[cfg_attr(target_arch = "wasm32", worker::send)]
-async fn replay_ui() -> impl IntoResponse {
-    Html(replay::replay_ui_html())
+async fn app_ui() -> impl IntoResponse {
+    Html(ui::app_html())
 }
 
 #[cfg_attr(target_arch = "wasm32", worker::send)]
@@ -1743,6 +1771,21 @@ async fn replay_sessions(
     match client.list_sessions(query).await {
         Ok(response) => Json(response).into_response(),
         Err(err) => replay_error_response(err),
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", worker::send)]
+async fn product_analytics(
+    State(state): State<AppState>,
+    axum::extract::Query(query): axum::extract::Query<ProductAnalyticsQuery>,
+) -> impl IntoResponse {
+    let Some(client) = state.analytics.as_ref() else {
+        return product_analytics_error_response(ProductAnalyticsError::NotConfigured);
+    };
+
+    match client.query(query).await {
+        Ok(response) => Json(response).into_response(),
+        Err(err) => product_analytics_error_response(err),
     }
 }
 
@@ -1841,6 +1884,33 @@ fn replay_error_response(err: ReplayError) -> axum::response::Response {
 
     if status.is_server_error() {
         error!(error = %err, "replay request failed");
+    }
+
+    (
+        status,
+        Json(ErrorResponse {
+            status: 0,
+            error: err.to_string(),
+        }),
+    )
+        .into_response()
+}
+
+fn product_analytics_error_response(err: ProductAnalyticsError) -> axum::response::Response {
+    let status = match &err {
+        ProductAnalyticsError::NotConfigured => StatusCode::SERVICE_UNAVAILABLE,
+        ProductAnalyticsError::Serialize(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        ProductAnalyticsError::Failed(_) | ProductAnalyticsError::InvalidResponse(_) => {
+            StatusCode::BAD_GATEWAY
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        ProductAnalyticsError::Process(_) => StatusCode::BAD_GATEWAY,
+        #[cfg(target_arch = "wasm32")]
+        ProductAnalyticsError::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+    };
+
+    if status.is_server_error() {
+        error!(error = %err, "analytics request failed");
     }
 
     (

--- a/src/product_analytics.rs
+++ b/src/product_analytics.rs
@@ -1,0 +1,417 @@
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::PathBuf;
+#[cfg(not(target_arch = "wasm32"))]
+use std::process::Stdio;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+#[cfg(not(target_arch = "wasm32"))]
+use serde_json::{json, Value};
+use thiserror::Error;
+
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines},
+    process::{Child, ChildStdin, ChildStdout, Command},
+    sync::Mutex,
+};
+
+#[derive(Debug, Clone)]
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub struct ProductAnalyticsConfig {
+    account_id: String,
+    bucket_name: String,
+    auth_token: String,
+    events_table: String,
+}
+
+impl ProductAnalyticsConfig {
+    pub fn new(
+        account_id: String,
+        bucket_name: String,
+        auth_token: String,
+        events_table: Option<String>,
+    ) -> Self {
+        Self {
+            account_id,
+            bucket_name,
+            auth_token,
+            events_table: events_table.unwrap_or_else(|| "default.hogflare_events".to_string()),
+        }
+    }
+}
+
+#[derive(Clone)]
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub struct ProductAnalyticsClient {
+    config: ProductAnalyticsConfig,
+    #[cfg(not(target_arch = "wasm32"))]
+    worker: std::sync::Arc<Mutex<Option<SidemanticWorker>>>,
+    #[cfg(not(target_arch = "wasm32"))]
+    request_id: std::sync::Arc<AtomicU64>,
+}
+
+impl ProductAnalyticsClient {
+    pub fn new(config: ProductAnalyticsConfig) -> Self {
+        Self {
+            config,
+            #[cfg(not(target_arch = "wasm32"))]
+            worker: std::sync::Arc::new(Mutex::new(None)),
+            #[cfg(not(target_arch = "wasm32"))]
+            request_id: std::sync::Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn query(
+        &self,
+        query: ProductAnalyticsQuery,
+    ) -> Result<ProductAnalyticsResponse, ProductAnalyticsError> {
+        let request_id = self.request_id.fetch_add(1, Ordering::Relaxed) + 1;
+        let mut payload_value =
+            serde_json::to_value(query).map_err(ProductAnalyticsError::Serialize)?;
+        if let Value::Object(fields) = &mut payload_value {
+            fields.insert("_request_id".to_string(), json!(request_id));
+        }
+        let payload =
+            serde_json::to_string(&payload_value).map_err(ProductAnalyticsError::Serialize)?;
+        let runtime = SidemanticRuntimeConfig::from_config(&self.config);
+        let mut worker = self.worker.lock().await;
+        if worker
+            .as_ref()
+            .map(|existing| existing.runtime != runtime)
+            .unwrap_or(true)
+        {
+            *worker = Some(SidemanticWorker::start(runtime.clone(), &self.config).await?);
+        }
+
+        let active = worker
+            .as_mut()
+            .expect("sidemantic worker must be initialized before querying");
+        match active.query(&payload, request_id).await {
+            Ok(response) => Ok(response),
+            Err(err) if err.should_restart_worker() => {
+                drop(worker.take());
+                let mut restarted = SidemanticWorker::start(runtime, &self.config).await?;
+                let response = restarted
+                    .query(&payload, request_id)
+                    .await
+                    .map_err(SidemanticWorkerError::into_product_analytics_error)?;
+                *worker = Some(restarted);
+                Ok(response)
+            }
+            Err(err) => Err(err.into_product_analytics_error()),
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub async fn query(
+        &self,
+        _query: ProductAnalyticsQuery,
+    ) -> Result<ProductAnalyticsResponse, ProductAnalyticsError> {
+        Err(ProductAnalyticsError::Unavailable)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ProductAnalyticsError {
+    #[error("product analytics is not configured")]
+    NotConfigured,
+    #[error("failed to serialize sidemantic analytics query: {0}")]
+    Serialize(#[source] serde_json::Error),
+    #[error("failed to run sidemantic analytics: {0}")]
+    #[cfg(not(target_arch = "wasm32"))]
+    Process(#[source] std::io::Error),
+    #[error("sidemantic analytics failed: {0}")]
+    Failed(String),
+    #[error("sidemantic analytics requires the native runtime")]
+    #[cfg(target_arch = "wasm32")]
+    Unavailable,
+    #[error("invalid sidemantic analytics response: {0}")]
+    InvalidResponse(#[source] serde_json::Error),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ProductAnalyticsQuery {
+    #[serde(default)]
+    pub api_key: Option<String>,
+    #[serde(default)]
+    pub distinct_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub event_name: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub date_from: Option<String>,
+    #[serde(default)]
+    pub date_to: Option<String>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+    #[serde(default)]
+    pub metric: Option<String>,
+    #[serde(default)]
+    pub dimension: Option<String>,
+    #[serde(default)]
+    pub granularity: Option<String>,
+    #[serde(default)]
+    pub semantic_filters: Option<String>,
+    #[serde(default)]
+    pub panel: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ProductAnalyticsResponse {
+    pub focus: ProductAnalyticsFocus,
+    pub summary: Vec<ProductAnalyticsMetric>,
+    pub series: Vec<ProductAnalyticsSeriesPoint>,
+    pub breakdowns: Vec<ProductAnalyticsBreakdown>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ProductAnalyticsFocus {
+    pub metric: String,
+    pub metric_label: String,
+    pub dimension: String,
+    pub dimension_label: String,
+    pub granularity: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ProductAnalyticsMetric {
+    pub label: String,
+    pub value: f64,
+    pub display_value: String,
+    pub model: String,
+    pub metric: String,
+    pub semantic_ref: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ProductAnalyticsSeriesPoint {
+    pub bucket: String,
+    pub event_count: usize,
+    pub pageviews: usize,
+    pub session_count: usize,
+    pub recordings: usize,
+    pub focused_value: f64,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ProductAnalyticsBreakdown {
+    pub title: String,
+    pub model: String,
+    pub dimension: String,
+    pub metric: String,
+    pub rows: Vec<ProductAnalyticsBreakdownRow>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ProductAnalyticsBreakdownRow {
+    pub label: String,
+    pub value: f64,
+    pub percent: f64,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub is_other: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, PartialEq, Eq)]
+struct SidemanticRuntimeConfig {
+    manifest_dir: PathBuf,
+    script_path: PathBuf,
+    model_dir: String,
+    persons_table: String,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl SidemanticRuntimeConfig {
+    fn from_config(config: &ProductAnalyticsConfig) -> Self {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let script_path = std::env::var("HOGFLARE_ANALYTICS_SIDEMANTIC_SCRIPT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| manifest_dir.join("scripts/product_analytics_sidemantic.py"));
+        let model_dir = std::env::var("HOGFLARE_ANALYTICS_MODEL_DIR")
+            .unwrap_or_else(|_| manifest_dir.join("models").display().to_string());
+        let persons_table = std::env::var("HOGFLARE_ANALYTICS_PERSONS_TABLE")
+            .unwrap_or_else(|_| infer_persons_table(&config.events_table));
+
+        Self {
+            manifest_dir,
+            script_path,
+            model_dir,
+            persons_table,
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct SidemanticWorker {
+    runtime: SidemanticRuntimeConfig,
+    child: Child,
+    stdin: ChildStdin,
+    stdout: Lines<BufReader<ChildStdout>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl SidemanticWorker {
+    async fn start(
+        runtime: SidemanticRuntimeConfig,
+        config: &ProductAnalyticsConfig,
+    ) -> Result<Self, ProductAnalyticsError> {
+        let mut child = Command::new("uv")
+            .arg("run")
+            .arg("--script")
+            .arg(&runtime.script_path)
+            .arg("--serve")
+            .current_dir(&runtime.manifest_dir)
+            .env("HOGFLARE_ANALYTICS_ACCOUNT_ID", &config.account_id)
+            .env("HOGFLARE_ANALYTICS_BUCKET", &config.bucket_name)
+            .env("HOGFLARE_ANALYTICS_R2_SQL_TOKEN", &config.auth_token)
+            .env("HOGFLARE_ANALYTICS_EVENTS_TABLE", &config.events_table)
+            .env("HOGFLARE_ANALYTICS_PERSONS_TABLE", &runtime.persons_table)
+            .env("HOGFLARE_ANALYTICS_MODEL_DIR", &runtime.model_dir)
+            .env("UV_NO_PROGRESS", "1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(ProductAnalyticsError::Process)?;
+
+        let stdin = child.stdin.take().ok_or_else(|| {
+            ProductAnalyticsError::Process(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "sidemantic worker stdin was not available",
+            ))
+        })?;
+        let stdout = child.stdout.take().ok_or_else(|| {
+            ProductAnalyticsError::Process(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "sidemantic worker stdout was not available",
+            ))
+        })?;
+
+        Ok(Self {
+            runtime,
+            child,
+            stdin,
+            stdout: BufReader::new(stdout).lines(),
+        })
+    }
+
+    async fn query(
+        &mut self,
+        payload: &str,
+        request_id: u64,
+    ) -> Result<ProductAnalyticsResponse, SidemanticWorkerError> {
+        self.stdin
+            .write_all(payload.as_bytes())
+            .await
+            .map_err(SidemanticWorkerError::Process)?;
+        self.stdin
+            .write_all(b"\n")
+            .await
+            .map_err(SidemanticWorkerError::Process)?;
+        self.stdin
+            .flush()
+            .await
+            .map_err(SidemanticWorkerError::Process)?;
+
+        loop {
+            let Some(line) = self
+                .stdout
+                .next_line()
+                .await
+                .map_err(SidemanticWorkerError::Process)?
+            else {
+                return Err(SidemanticWorkerError::Eof);
+            };
+            if line.trim().is_empty() {
+                continue;
+            }
+            let envelope: SidemanticWorkerEnvelope =
+                serde_json::from_str(&line).map_err(SidemanticWorkerError::InvalidResponse)?;
+            if envelope.request_id != Some(request_id) {
+                continue;
+            }
+            if envelope.ok {
+                return envelope.result.ok_or_else(|| {
+                    SidemanticWorkerError::Analytics(
+                        "sidemantic worker returned ok without a result".to_string(),
+                    )
+                });
+            }
+            return Err(SidemanticWorkerError::Analytics(
+                envelope
+                    .error
+                    .unwrap_or_else(|| "sidemantic worker returned an analytics error".to_string()),
+            ));
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for SidemanticWorker {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Deserialize)]
+struct SidemanticWorkerEnvelope {
+    ok: bool,
+    request_id: Option<u64>,
+    result: Option<ProductAnalyticsResponse>,
+    error: Option<String>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+enum SidemanticWorkerError {
+    Process(std::io::Error),
+    Eof,
+    InvalidResponse(serde_json::Error),
+    Analytics(String),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl SidemanticWorkerError {
+    fn should_restart_worker(&self) -> bool {
+        matches!(
+            self,
+            Self::Process(_) | Self::Eof | Self::InvalidResponse(_)
+        )
+    }
+
+    fn into_product_analytics_error(self) -> ProductAnalyticsError {
+        match self {
+            Self::Process(err) => ProductAnalyticsError::Process(err),
+            Self::Eof => ProductAnalyticsError::Process(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "sidemantic worker exited before returning analytics",
+            )),
+            Self::InvalidResponse(err) => ProductAnalyticsError::InvalidResponse(err),
+            Self::Analytics(message) => ProductAnalyticsError::Failed(message),
+        }
+    }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn infer_persons_table(events_table: &str) -> String {
+    for (needle, replacement) in [
+        ("hogflare_events_v3", "hogflare_persons_v2"),
+        ("hogflare_events", "hogflare_persons"),
+        ("events", "persons"),
+    ] {
+        if events_table.contains(needle) {
+            return events_table.replace(needle, replacement);
+        }
+    }
+    "default.hogflare_persons_v2".to_string()
+}

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -81,7 +81,7 @@ pub enum ReplayConfigError {
     InvalidQueryLimit { value: String, message: String },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ReplayClient {
     config: ReplayConfig,
     #[cfg(not(target_arch = "wasm32"))]
@@ -696,7 +696,7 @@ pub struct ReplayActivityItem {
 
 #[derive(Debug, Serialize)]
 pub struct ReplayEventsResponse {
-    pub events: Vec<ReplayAnalyticsEvent>,
+    pub events: Vec<ReplayEventSummary>,
 }
 
 #[derive(Debug, Serialize)]
@@ -768,7 +768,7 @@ pub struct ReplayPersonJourneyResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub distinct_id: Option<String>,
     pub sessions: Vec<ReplaySessionSummary>,
-    pub events: Vec<ReplayAnalyticsEvent>,
+    pub events: Vec<ReplayEventSummary>,
     pub timeline: Vec<ReplayPersonTimelineItem>,
 }
 
@@ -786,7 +786,7 @@ pub struct ReplayPersonTimelineItem {
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
-pub struct ReplayAnalyticsEvent {
+pub struct ReplayEventSummary {
     pub uuid: String,
     pub event: String,
     pub distinct_id: String,
@@ -1043,7 +1043,7 @@ pub fn build_session_events_response(
 pub fn build_events_response(rows: Vec<ReplayEventRow>, limit: usize) -> ReplayEventsResponse {
     let mut events = rows
         .into_iter()
-        .map(ReplayAnalyticsEvent::from)
+        .map(ReplayEventSummary::from)
         .collect::<Vec<_>>();
     events.sort_by(|a, b| b.created_at.cmp(&a.created_at));
     events.truncate(limit);
@@ -1062,9 +1062,9 @@ pub fn build_funnel_response(
         };
     }
 
-    let mut grouped: HashMap<String, Vec<ReplayAnalyticsEvent>> = HashMap::new();
+    let mut grouped: HashMap<String, Vec<ReplayEventSummary>> = HashMap::new();
     for row in rows {
-        let event = ReplayAnalyticsEvent::from(row);
+        let event = ReplayEventSummary::from(row);
         let key = event
             .session_id
             .clone()
@@ -1133,7 +1133,7 @@ pub fn build_friction_response(
 pub fn build_person_journey_response(
     distinct_id: Option<String>,
     sessions: Vec<ReplaySessionSummary>,
-    events: Vec<ReplayAnalyticsEvent>,
+    events: Vec<ReplayEventSummary>,
     limit: usize,
 ) -> ReplayPersonJourneyResponse {
     let mut timeline = Vec::new();
@@ -1204,11 +1204,7 @@ pub fn rows_from_r2_sql_response(value: Value) -> Result<Vec<Value>, ReplayError
     Err(ReplayError::MissingRows)
 }
 
-pub fn replay_ui_html() -> &'static str {
-    include_str!("replay_ui.html")
-}
-
-impl From<ReplayEventRow> for ReplayAnalyticsEvent {
+impl From<ReplayEventRow> for ReplayEventSummary {
     fn from(row: ReplayEventRow) -> Self {
         let session_id = session_id_from_value(&row.properties);
         let url = event_url_from_properties(&row.properties);
@@ -1229,7 +1225,7 @@ impl From<ReplayEventRow> for ReplayAnalyticsEvent {
 }
 
 fn funnel_session_from_events(
-    events: &[ReplayAnalyticsEvent],
+    events: &[ReplayEventSummary],
     steps: &[String],
 ) -> Option<ReplayFunnelSession> {
     let first = events.first()?;
@@ -1633,7 +1629,7 @@ fn current_url_at(events: &[Value], timestamp: i64) -> Option<String> {
         .last()
 }
 
-fn event_property_line(event: &ReplayAnalyticsEvent) -> String {
+fn event_property_line(event: &ReplayEventSummary) -> String {
     if event.properties.is_empty() {
         return event
             .url
@@ -2302,7 +2298,7 @@ mod tests {
         }
     }
 
-    fn analytics_row(
+    fn event_row(
         uuid: &str,
         event: &str,
         session_id: &str,
@@ -2475,7 +2471,7 @@ mod tests {
     }
 
     #[test]
-    fn builds_analytics_event_response_without_raw_properties() {
+    fn builds_event_response_without_raw_properties() {
         let response = build_events_response(
             vec![ReplayEventRow {
                 uuid: "event-1".to_string(),
@@ -2513,13 +2509,13 @@ mod tests {
     fn classifies_funnel_sessions() {
         let response = build_funnel_response(
             vec![
-                analytics_row("a1", "Viewed Pricing", "converted", "user-a", 1_000),
-                analytics_row("a2", "Checkout Started", "converted", "user-a", 2_000),
-                analytics_row("a3", "Paid", "converted", "user-a", 3_000),
-                analytics_row("b1", "Viewed Pricing", "stuck", "user-b", 4_000),
-                analytics_row("b2", "Viewed Pricing", "stuck", "user-b", 5_000),
-                analytics_row("c1", "Viewed Pricing", "dropped", "user-c", 6_000),
-                analytics_row("d1", "Signed Up", "ignored", "user-d", 7_000),
+                event_row("a1", "Viewed Pricing", "converted", "user-a", 1_000),
+                event_row("a2", "Checkout Started", "converted", "user-a", 2_000),
+                event_row("a3", "Paid", "converted", "user-a", 3_000),
+                event_row("b1", "Viewed Pricing", "stuck", "user-b", 4_000),
+                event_row("b2", "Viewed Pricing", "stuck", "user-b", 5_000),
+                event_row("c1", "Viewed Pricing", "dropped", "user-c", 6_000),
+                event_row("d1", "Signed Up", "ignored", "user-d", 7_000),
             ],
             vec![
                 "Viewed Pricing".to_string(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,3 @@
+pub fn app_html() -> &'static str {
+    include_str!("app_ui.html")
+}

--- a/tests/posthog_endpoints.rs
+++ b/tests/posthog_endpoints.rs
@@ -932,7 +932,7 @@ async fn replay_ui_lists_and_loads_session_events() -> Result<(), Box<dyn std::e
     let ui_response = client.get(format!("{}/replay", base_url)).send().await?;
     assert!(ui_response.status().is_success());
     let ui = ui_response.text().await?;
-    assert!(ui.contains("Replay Explorer"));
+    assert!(ui.contains("<title>Hogflare</title>"));
     assert!(ui.contains("aria-label=\"Hogflare\""));
     assert!(ui.contains("id=\"status\" hidden"));
     assert!(ui.contains("Activity timeline"));

--- a/tests/posthog_endpoints.rs
+++ b/tests/posthog_endpoints.rs
@@ -939,6 +939,10 @@ async fn replay_ui_lists_and_loads_session_events() -> Result<(), Box<dyn std::e
     assert!(ui.contains("Date range"));
     assert!(ui.contains("type=\"datetime-local\""));
     assert!(ui.contains("data-date-preset=\"24h\""));
+    assert!(ui.contains("data-date-preset=\"30d\" aria-pressed=\"true\""));
+    assert!(ui.contains("<option value=\"hour\">Hour</option>"));
+    assert!(ui.contains("id=\"clear\" type=\"button\" data-section=\"replays\""));
+    assert!(!ui.contains(">Reset<"));
     assert!(ui.contains("aria-label=\"Hide filters\""));
     assert!(ui.contains("aria-label=\"Hide context\""));
     assert!(ui.contains(">Search<"));


### PR DESCRIPTION
Adds a first-class product analytics view at /analytics backed by Sidemantic, with independent chart panel loading, top-10 plus Others leaderboards, cross-filtering, and analytics-specific config/env names.

Moves the shared app shell out of replay, removes /replay/api/charts, and keeps /replay as the replay feature.